### PR TITLE
Port native XR editor preview plan + agent prompt

### DIFF
--- a/Docs/DisplayXR/EditorPreviewNative-AgentPrompt.md
+++ b/Docs/DisplayXR/EditorPreviewNative-AgentPrompt.md
@@ -1,0 +1,92 @@
+# Agent Prompt — Editor Preview Native XR Path
+
+Copy-paste the block below into a fresh Claude Code session to kick
+off Phase 1 of the investigation.
+
+---
+
+You're picking up a research + implementation task in the
+`DisplayXR/displayxr-unreal` repository. Your working directory should
+be a local clone of this repo.
+
+## Your job
+
+Read [`Docs/DisplayXR/EditorPreviewNative.md`](./EditorPreviewNative.md) first — that's the plan.
+Then execute Phase 1 (instrument `FDisplayXRDevice` and log which of
+its methods UE actually calls during PIE startup vs game-mode
+startup). Report findings before starting Phase 2.
+
+## What's already shipped
+
+The current editor preview is `SceneCapture2D`-based and lives in
+`Source/DisplayXREditor/Private/DisplayXRPreviewSession.*`. It works.
+See [`Docs/DisplayXR/EditorPreview.md`](./EditorPreview.md) for the
+current approach. This task is about replacing it with a native XR
+render path, not fixing the SceneCapture one.
+
+## The load-bearing claim to re-verify
+
+Prior investigation concluded that `FDisplayXRDevice::UpdateViewport`
+is never called in PIE — which blocked the direct compositor approach.
+But Epic's `OpenXRHMD` plugin works in PIE on UE 5.5+, so there's a
+hook pattern we didn't discover before. Phase 1 + Phase 2 in the plan
+are specifically about finding that pattern.
+
+## What NOT to do yet
+
+- Don't modify game-mode rendering code (`DisplayXRCompositor`,
+  `DisplayXRDevice.cpp` beyond adding logs). Game mode works; don't
+  regress it.
+- Don't delete the current editor preview (`DisplayXRPreviewSession`
+  etc.) until Phase 4 is proven. It's the fallback.
+- Don't rewrite `FDisplayXRDevice` as a thin `FOpenXRHMD` extension.
+  That's a different architecture — stay with the custom HMD path
+  and find the PIE activation hook.
+
+## Constraints
+
+- UE 5.5+, Windows, DX12 (primary target for this task)
+- Mac / Android out of scope for the native-PIE investigation
+- DisplayXR naming only — the repo is vendor-neutral
+- Build path: install the plugin into a UE test project's
+  `Plugins/DisplayXR/` folder, then build via the usual UE workflow
+  (Visual Studio solution or
+  `<UE_ROOT>/Engine/Build/BatchFiles/Build.bat <Project>Editor Win64 Development -Project=<path-to-.uproject> -WaitMutex -FromMsBuild`).
+  Kill any running `UnrealEditor` / `LiveCodingConsole` before
+  rebuilding.
+- Use the UE project's `Saved/Logs/<ProjectName>.log` for verification
+  — read it with the Grep tool.
+
+## First concrete step
+
+Open `Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp`
+and `Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.h`.
+Add a one-line `UE_LOG` at the top of each of these methods, with
+enough context to tell editor-from-PIE apart (include
+`GEditor->PlayWorld != nullptr` or equivalent as a flag in the log):
+
+- `UpdateViewport(...)`
+- `EnableStereo(bool)` / `IsStereoEnabled()` (log enable/disable state
+  transitions only — these run every frame)
+- `ShouldUseSeparateRenderTarget()` (log once per world context
+  change — also every-frame)
+- `GetIdealRenderTargetSize()`
+- `AllocateRenderTargetTexture(...)` / `AllocateDepthTexture(...)`
+- `BeginRenderViewFamily` / `SetupViewFamily` /
+  `PreRenderViewFamily_RenderThread`
+- `OnBeginPlay(FWorldContext&)`
+
+Then build, launch the editor, press Play, and collect the log. Share
+the sequence you see — that tells us which hooks fire and which
+don't, which is the whole point of Phase 1.
+
+## Reference
+
+- Plan: [`Docs/DisplayXR/EditorPreviewNative.md`](./EditorPreviewNative.md)
+- Current preview (to be replaced): [`Docs/DisplayXR/EditorPreview.md`](./EditorPreview.md)
+- Atlas handoff (zero-copy pipeline the game path already uses): [`Docs/DisplayXR/AtlasHandoff.md`](./AtlasHandoff.md)
+- Eye-tracking / Kooima pipeline: [`Docs/DisplayXR/EyeTracking.md`](./EyeTracking.md)
+- Epic source (read-only): `%UE_ROOT%/Engine/Plugins/Runtime/OpenXR/Source/OpenXRHMD/Private/OpenXRHMD.cpp`
+
+Ask clarifying questions if anything about the plan or setup is
+ambiguous.

--- a/Docs/DisplayXR/EditorPreviewNative.md
+++ b/Docs/DisplayXR/EditorPreviewNative.md
@@ -1,0 +1,173 @@
+# Editor Preview: Native XR Path
+
+## Context
+
+The current editor preview (see [EditorPreview.md](./EditorPreview.md))
+uses `USceneCaptureComponent2D` + a standalone OpenXR session to render
+the PIE world into a native 3D window. It works, but has inherent
+limitations:
+
+1. **No UMG / HUD capture** — `SceneCapture2D` doesn't render UI widgets
+2. **Duplicate render path** — the main PIE viewport renders once, the
+   preview captures again, so state (TAA history, eye-adaptation,
+   post-process) has to be manually coerced to match
+3. **Not zero-copy** — intermediate render targets + `CopyTextureRegion`
+   to the swapchain
+
+Game mode already solves all three via the custom HMD / compositor path
+in `DisplayXRCore` — UE renders directly into the OpenXR swapchain
+wrapped as an RHI texture. This plan is about making **PIE** use the
+same path, eliminating the SceneCapture workaround.
+
+## Why this failed before
+
+From prior investigation of the PIE render path:
+
+> UE's PIE rendering path does NOT call
+> `FDisplayXRDevice::UpdateViewport()`. The XR device's viewport
+> management functions are only called in standalone game mode, not in
+> the editor's PIE. The compositor never initializes because
+> `UpdateViewport` is never invoked.
+
+This is the single load-bearing claim to re-verify. Every UE XR plugin
+(OpenXR, SteamVR, Meta, etc.) works in PIE — so there **is** a hook
+pattern that activates an XR device for PIE rendering. We either
+missed it or `FDisplayXRDevice` isn't registered in a way UE recognizes
+for PIE.
+
+## Goal
+
+Make `FDisplayXRDevice` render PIE viewport output directly into the
+DisplayXR OpenXR swapchain, matching game-mode behavior. When this
+works:
+
+- PIE viewport in the editor renders stereo through our compositor
+- UMG / HUD widgets are included (they render into the main viewport)
+- The native 3D preview window simply *mirrors* the swapchain (or goes
+  away entirely — the runtime outputs directly to the 3D display)
+- No SceneCapture, no copy, no POV reconstruction
+
+## Investigation plan
+
+### Phase 1 — Verify the failure is still a failure
+
+Instrument `FDisplayXRDevice` to log when each of these fires, with
+timestamp + world context (editor / PIE):
+
+- `UpdateViewport(bUseSeparateRT, FViewport&)` — the original claimed-not-called method
+- `EnableStereo(bool)` / `IsStereoEnabled()` — UE queries these to decide XR mode
+- `ShouldUseSeparateRenderTarget()` — gates whether UE wants an XR RT
+- `GetIdealRenderTargetSize()` — called when UE sizes the XR RT
+- `AllocateRenderTargetTexture(...)` / `AllocateDepthTexture(...)` — where we wrap the swapchain
+- `BeginRenderViewFamily` / `SetupViewFamily` / `PreRenderViewFamily_RenderThread` — the `FSceneViewExtensionBase` callbacks
+
+Run the editor, open a level with a rig, press Play. Compare the log
+sequence to what a **working** UE XR plugin does — easiest comparator
+is Epic's `OpenXRHMD` (engine plugin `Engine/Plugins/Runtime/OpenXR/`).
+
+The point is: build ground truth about what UE actually calls in PIE
+on our device, vs what we need it to call.
+
+### Phase 2 — Read OpenXRHMD source for the PIE hook pattern
+
+UE's `OpenXRHMD` works in PIE. Relevant code to study:
+
+- `Engine/Plugins/Runtime/OpenXR/Source/OpenXRHMD/Private/OpenXRHMD.cpp` — session lifecycle, `OnBeginPlay`, stereo activation
+- `Engine/Source/Runtime/Engine/Private/GameViewportClient.cpp` — look for where `IStereoRendering` / `IHeadMountedDisplay` methods fire during PIE draw
+- `Engine/Source/Runtime/HeadMountedDisplay/` — the base classes we extend
+
+Key questions:
+1. At what point in PIE startup does UE activate stereo on the HMD?
+   Is it a call we're missing (e.g., `UGameUserSettings::EnableHMD`)?
+2. Does `FOpenXRHMD` register itself differently than we do (e.g.,
+   `GEngine->XRSystem`, `IModularFeatures`, priority)?
+3. Does PIE need `GEngine->XRSystem` to be set via
+   `IHeadMountedDisplayModule::CreateTrackingSystem` on PIE begin, or
+   is it a one-time registration at module load?
+
+### Phase 3 — Match the hook pattern
+
+Based on Phase 2 findings, adjust `FDisplayXRDevice` registration /
+activation so UE drives it through the PIE render path. Candidate
+changes:
+
+- Register as `IModularFeatures` with the right feature name / priority
+- Ensure `IsStereoEnabled()` returns true once the plugin module starts
+  (not only after `EnableStereo(true)` is called)
+- Implement `OnStartGameFrame` / `OnBeginPlay` to engage the compositor
+  at PIE begin
+- Handle `FWorldDelegates::OnWorldBeginPlay` to spin up per-world state
+
+### Phase 4 — Wire PIE viewport → compositor
+
+Once UE calls our XR path in PIE:
+
+- `AllocateRenderTargetTexture` wraps the DisplayXR swapchain image as
+  a `PF_B8G8R8A8` RHI texture (same pattern as the zero-copy wrap in
+  `DisplayXRCompositor.cpp`)
+- `FSceneViewExtensionBase` callbacks apply Kooima projection via
+  `ComputeViews` (already implemented for game mode in
+  `DisplayXRDevice.cpp`)
+- `xrEndFrame` submits the rendered image — runtime handles interlace
+  and outputs to the 3D display directly
+
+### Phase 5 — Reconcile with the current editor preview
+
+Once PIE rendering works natively:
+
+- The native preview window may become redundant (the display itself is
+  the preview). Delete `FDisplayXRPreviewSession` entirely.
+- Or keep a small secondary window that mirrors the swapchain for cases
+  where the 3D display isn't the primary monitor. Simpler than the
+  current SceneCapture path.
+- Close the "SceneCapture vs native" tension in `EditorPreview.md`.
+
+## Risks
+
+- **Failure case**: if Phase 2 reveals UE genuinely requires an
+  `FOpenXRHMD`-managed session for PIE XR, our custom device may not
+  fit. Fallback: keep the SceneCapture approach as shipped.
+- **Regression risk**: touching `FDisplayXRDevice` registration can
+  break game mode. Build and test standalone first after every
+  meaningful change.
+- **Time sink**: this is a research-heavy task with uncertain
+  outcomes. Set a timebox (e.g., 1–2 days of exploration) — if
+  Phase 1/2 don't yield a clear path, pause and re-evaluate.
+
+## Not doing (out of scope)
+
+- Replacing `FDisplayXRDevice` with a thin `FOpenXRHMD` extension.
+  That's a different architecture; don't mix with this investigation.
+- Mac / Android support.
+
+## Critical files
+
+### Existing — reference only (don't modify until Phase 4)
+- `Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp` —
+  current custom HMD device (game-mode path)
+- `Source/DisplayXRCore/Private/DisplayXRCompositor.cpp` —
+  zero-copy swapchain wrapping pattern
+- `Source/DisplayXRCore/Private/DisplayXRSession.cpp` — OpenXR session
+  lifecycle
+- `Source/DisplayXREditor/Private/DisplayXRPreviewSession.cpp` — the
+  current SceneCapture-based editor preview (to be removed in Phase 5)
+
+### Engine reference (read-only, for Phase 2)
+- `%UE_ROOT%/Engine/Plugins/Runtime/OpenXR/Source/OpenXRHMD/Private/OpenXRHMD.cpp`
+- `%UE_ROOT%/Engine/Source/Runtime/Engine/Private/GameViewportClient.cpp`
+- `%UE_ROOT%/Engine/Source/Runtime/HeadMountedDisplay/Public/IHeadMountedDisplay.h`
+- `%UE_ROOT%/Engine/Source/Runtime/HeadMountedDisplay/Public/IXRTrackingSystem.h`
+
+## Verification
+
+After Phase 4 implementation:
+
+1. Open a test project with the plugin installed in UE 5.5+ editor
+2. Place rig pawn in level, possess on BeginPlay
+3. Press Play → editor PIE viewport should render stereo through our
+   compositor. The 3D display should show correct stereo output.
+4. UMG widgets added to the level should appear in both PIE viewport
+   and on the 3D display.
+5. Standalone game mode (`-game`) still renders correctly (regression
+   check).
+6. Second Play cycle works without restart.

--- a/Docs/DisplayXR/README.md
+++ b/Docs/DisplayXR/README.md
@@ -8,7 +8,8 @@ Unreal Engine integration with the DisplayXR OpenXR runtime for eye-tracked 3D l
 - [Compositor Integration](./CompositorIntegration.md) — Original Phase 2 planning doc (historical)
 - [Display Rig Setup](./DisplayRigSetup.md) — How to set up the pawn/camera rig for stereo 3D (camera rotation, input, display-centric vs camera-centric)
 - [Eye Tracking](./EyeTracking.md) — Parallax pipeline: `xrLocateViews` → Kooima → per-view projection, coordinate conventions
-- [Editor Preview](./EditorPreview.md) — Preview strategy, Unity vs Unreal differences
+- [Editor Preview](./EditorPreview.md) — Current `SceneCapture2D`-based preview strategy, Unity vs Unreal differences
+- [Editor Preview: Native XR Path](./EditorPreviewNative.md) — In-flight plan to replace the current preview with a native `FDisplayXRDevice` → PIE hookup (see also the [agent prompt](./EditorPreviewNative-AgentPrompt.md))
 - [Mac Setup](./MacSetup.md) — macOS-specific setup, direct OpenXR session, scene view extension
 - [TODO](./TODO.md) — Outstanding work, parity with the Unity sibling, in-flight branches
 

--- a/Docs/DisplayXR/TODO.md
+++ b/Docs/DisplayXR/TODO.md
@@ -10,8 +10,7 @@ Outstanding work for the DisplayXR Unreal plugin. Organized by theme, not priori
 Replace the current `SceneCapture2D`-based editor preview with a `FDisplayXRDevice` → PIE hookup so UE renders directly into the OpenXR swapchain in the editor (zero-copy, UMG/HUD supported).
 
 - Motivation: remove duplicate render path, pick up TAA history / eye adaptation / post-process state automatically, include UI widgets in the preview.
-- Design + agent prompt already drafted; not yet merged into this repo. When picked up, port `EditorPreviewNative.md` + `EditorPreviewNative-AgentPrompt.md` into `Docs/DisplayXR/`.
-- Key hypothesis to re-verify: UE's PIE pipeline does not invoke `FDisplayXRDevice::UpdateViewport()`. Every working UE XR plugin (OpenXR, SteamVR, Meta) activates in PIE, so the hook pattern exists — it was either missed or the device isn't registered in a way UE recognizes for PIE. First step: instrument `EnableStereo`, `IsStereoEnabled`, `ShouldUseSeparateRenderTarget`, `GetIdealRenderTargetSize`, `AllocateRenderTargetTexture`, `BeginRenderViewFamily`, compare sequence against Epic's `OpenXRHMD`.
+- Plan: [`EditorPreviewNative.md`](./EditorPreviewNative.md) (5-phase investigation). Agent handoff prompt: [`EditorPreviewNative-AgentPrompt.md`](./EditorPreviewNative-AgentPrompt.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Ports the 5-phase investigation plan and agent handoff prompt for replacing the current `SceneCapture2D`-based editor preview with a native `FDisplayXRDevice` → PIE hookup.

These docs previously lived only on the predecessor repo's `editor-preview-xr-native` branch. Without them here, any agent told to pick up the native-preview work has no primary source material. With them, the task is self-contained in this repo.

Cross-references to the deleted `Docs/Internal/` handoff docs and to the predecessor `LeiaUnrealSDK` repo/paths have been removed; the load-bearing historical claims (e.g. \"PIE does not call \`UpdateViewport\`\") are inlined.

## Files

- **Added** \`Docs/DisplayXR/EditorPreviewNative.md\` — 5-phase plan (context, why it failed before, goal, investigation phases 1–5, risks, out-of-scope, critical files, verification)
- **Added** \`Docs/DisplayXR/EditorPreviewNative-AgentPrompt.md\` — ready-to-paste prompt for kicking off Phase 1
- **Modified** \`Docs/DisplayXR/README.md\` — index entries for the two new docs
- **Modified** \`Docs/DisplayXR/TODO.md\` — link to plan, drop the \"not yet merged\" note

## Test plan

- [ ] \`lint.yml\` passes all three checks
- [ ] Manual: links in new docs resolve within this repo
- [ ] Manual: agent prompt reads as a self-contained handoff without predecessor-repo context