### PR TITLE
docs: Architecture, QuickStart, ADRs; correct stale dual-path docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,16 +28,11 @@ Output goes to `Packages/DisplayXR_<version>/`.
 2. **DisplayXRMaterials** (Runtime, all platforms, `Default`) — Custom material expression nodes (`StereoIndex`, `StereoSelect`, `SideBySideCoords`, `TopBottomCoords`).
 3. **DisplayXREditor** (Editor, `Win64|Mac`, `PostEngineInit`) — Editor preview session, viewport widget, component proxies.
 
-### Dual-Path OpenXR Integration
+### OpenXR Integration
 
-Selected at compile time via `DISPLAYXR_USE_UNREAL_OPENXR`:
+One unified session — `FDisplayXRSession` — loads the DisplayXR runtime **directly** on every platform (`LoadLibraryW` + `XrNegotiateLoaderRuntimeInterface` on Windows, `dlopen` on Mac/Linux). UE's `OpenXR` plugin is **not** a dependency; `DisplayXR.uplugin` declares only `XRBase`. `FDisplayXRCoreModule` implements `IHeadMountedDisplayModule` and bumps its HMD plugin priority +10 above `OpenXRHMD` / `SteamVR` so UE's HMD discovery picks us.
 
-| Path | Platforms | How |
-|---|---|---|
-| UE OpenXR hook | Windows, Android | `IOpenXRExtensionPlugin` intercepts `xrLocateViews`; UE's `FOpenXRHMD` owns the session |
-| Direct session | macOS | `FDisplayXRDirectSession` loads the runtime via `dlopen`; `FSceneViewExtensionBase` overrides projection |
-
-Everything above the OpenXR layer (components, rig manager, Kooima math, materials, Blueprint API) is shared.
+There is **no** `DISPLAYXR_USE_UNREAL_OPENXR` compile flag. Platform differences (DLL loading, window binding, D3D12 vs Metal graphics binding) live inside session and compositor code behind `#if PLATFORM_WINDOWS / PLATFORM_MAC / PLATFORM_LINUX`. See [`Docs/DisplayXR/Architecture.md`](./Docs/DisplayXR/Architecture.md) for the full picture and [`Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md`](./Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md) for why.
 
 ### Rendering Pipeline
 

--- a/Docs/DisplayXR/Architecture.md
+++ b/Docs/DisplayXR/Architecture.md
@@ -1,0 +1,129 @@
+# Architecture
+
+One-page reference for the DisplayXR Unreal plugin. Covers the class hierarchy, who owns what, and the per-frame data flow. Read this before touching session, device, or compositor code.
+
+## TL;DR
+
+- **One module**, `FDisplayXRCoreModule`, implements `IHeadMountedDisplayModule` and makes itself the active HMD with priority +10 above `OpenXRHMD` / `SteamVR`.
+- **One session**, `FDisplayXRSession`, loads the DisplayXR OpenXR runtime *directly* (not through UE's `OpenXRHMD`) and owns the `XrInstance` / `XrSession`.
+- **One custom HMD device**, `FDisplayXRDevice`, extending `FHeadMountedDisplayBase + FXRRenderTargetManager + FSceneViewExtensionBase`. UE drives it through the standard HMD interfaces.
+- **One compositor thread**, `FDisplayXRCompositor`, handles the `xrWaitFrame` / `xrBeginFrame` / `xrEndFrame` handshake off UE's game and render threads. UE renders directly into the OpenXR swapchain (zero-copy, see [AtlasHandoff.md](./AtlasHandoff.md)).
+- **No dual compile-time paths.** Platform differences (DLL loading, window binding, D3D12 vs Metal) live inside session and compositor code behind `#if PLATFORM_WINDOWS / PLATFORM_MAC / PLATFORM_LINUX`. There is no `DISPLAYXR_USE_UNREAL_OPENXR` or similar product-level flag — if you see it referenced somewhere, the doc is stale.
+
+## Module map
+
+| Module | Purpose | Load phase |
+|---|---|---|
+| `DisplayXRCore` | Session, device, compositor, rig components, Blueprint API, Kooima C libs | `PostConfigInit` |
+| `DisplayXRMaterials` | Material expression nodes (`StereoIndex`, `StereoSelect`, `SideBySideCoords`, `TopBottomCoords`) | `Default` |
+| `DisplayXREditor` | Editor preview session, component visualization proxies, rig editor UI | `PostEngineInit` (editor only) |
+
+Only the `XRBase` UE plugin is required (`DisplayXR.uplugin`). The plugin **does not** depend on UE's `OpenXR` plugin.
+
+## Class hierarchy
+
+```
+FDisplayXRCoreModule          (IHeadMountedDisplayModule)
+  ├── Owns FDisplayXRSession  (unified OpenXR runtime wrapper)
+  │     ├── XrInstance, XrSession, XrSpace handles
+  │     ├── Per-frame Tick(): xrPollEvent, xrLocateViews, stores eyes
+  │     ├── Double-buffered FDisplayXRTunables + FDisplayXRViewConfig
+  │     └── Owns FDisplayXRCompositor (on Windows/D3D12 path)
+  │           ├── Dedicated FRunnableThread (xrWaitFrame/Begin/End loop)
+  │           ├── OpenXR swapchain wrapped as TArray<FTextureRHIRef>
+  │           └── Per-frame BeginFrameReady ↔ EndFrameReady events
+  │
+  └── CreateTrackingSystem() → FDisplayXRDevice   (UE's view of the HMD)
+         : FHeadMountedDisplayBase     — IXRTrackingSystem / IHeadMountedDisplay
+         , FXRRenderTargetManager      — AllocateRenderTargetTexture, etc.
+         , FSceneViewExtensionBase     — SetupView, SetupViewPoint, PreRender, ...
+
+FDisplayXRPlatform (static)   — Routes API calls to the active session via
+                                FDisplayXRCoreModule::GetSession(). Components
+                                and Blueprint functions call this, never the
+                                session directly.
+
+FDisplayXRRigManager (static) — Registry of UCameraComponent ↔ UDisplayXRCamera
+                                pairs. Picks the active rig so only one pushes
+                                tunables per frame.
+
+UDisplayXRCamera (UActorComponent) — Camera-centric rig tunables
+UDisplayXRDisplay (UActorComponent) — Display-centric rig tunables
+
+[Editor module]
+FDisplayXRPreviewSession    — Current SceneCapture2D-based editor preview
+                              (see EditorPreview.md; replacement tracked in
+                              EditorPreviewNative.md).
+UDisplayXRCameraProxy /     — UPrimitiveComponent proxies for editor
+UDisplayXRDisplayProxy        visualization of the rig transform/frustum.
+```
+
+## Per-frame data flow (game mode, Windows/D3D12)
+
+```
+Compositor thread (independent loop):
+  1. xrWaitFrame                               (blocks on runtime vsync)
+  2. xrBeginFrame
+  3. Signal BeginFrameReadyEvent
+  4. Wait EndFrameReadyEvent (≤ 50ms timeout)
+  5. xrEndFrame with XrCompositionLayerProjection
+
+Game thread:
+  FDisplayXRSession::Tick()
+    → xrPollEvent (session state transitions)
+    → xrLocateViews (predictedDisplayTime)
+    → Write FDisplayXRViewConfig + eye positions to buffer[1-readIdx]
+    → Atomic swap read index
+
+  FDisplayXRDevice::UpdateViewport()
+    → FDisplayXRCompositor::AcquireImage_GameThread()
+        → Wait BeginFrameReadyEvent
+        → xrAcquireSwapchainImage + xrWaitSwapchainImage
+        → Return image index
+
+  UE scene setup runs. FSceneViewExtensionBase callbacks on FDisplayXRDevice
+  feed per-view Kooima projection into FSceneViewFamily.
+
+Render thread:
+  UE renders the scene directly into the acquired swapchain FRHITexture.
+  FDisplayXRCompositor::ReleaseImage_RenderThread()
+    → RHI transition → Present
+    → xrReleaseSwapchainImage
+    → Signal EndFrameReadyEvent     (unblocks step 4 of compositor loop)
+```
+
+The zero-copy detail — how the OpenXR swapchain image becomes an `FRHITexture` UE will render into — is in [AtlasHandoff.md](./AtlasHandoff.md).
+
+## Component interface (game code)
+
+Game code and Blueprint nodes never call `FDisplayXRSession` directly. They go through `FDisplayXRPlatform` (static helpers in `DisplayXRPlatform.h`):
+
+```cpp
+FDisplayXRPlatform::SetTunables(tunables);            // IPD / parallax / near-far
+FDisplayXRPlatform::SetSceneTransform(xform, bEnabled);
+FDisplayXRPlatform::GetDisplayInfo();                  // physical display dimensions
+FDisplayXRPlatform::GetEyePositions(L, R, bTracked);
+FDisplayXRPlatform::RequestDisplayMode(bMode3D);
+FDisplayXRPlatform::RequestEyeTrackingMode(bManual);
+```
+
+`FDisplayXRPlatform` routes to the active session. If no session is live (e.g. runtime not installed), calls no-op and return defaults — the game still runs in 2D.
+
+## Kooima math lives in portable C
+
+`Source/DisplayXRCore/Private/Native/{camera3d_view, display3d_view}.{c,h}` are portable C, shared byte-for-byte with the [displayxr-unity](https://github.com/DisplayXR/displayxr-unity) sibling plugin. Keep them engine-agnostic — no UE or Unity types. Sync changes both directions.
+
+`DisplayXRStereoMath.h` wraps the Kooima output into UE-native reverse-Z off-axis projection matrices (see [ADR-003](./adr/ADR-003-ue-native-off-axis-projection.md) for why we don't consume Kooima's `projection_matrix[16]` directly).
+
+## Platform notes
+
+- **Windows / D3D12** is the primary development path. Session loads the runtime DLL via `LoadLibraryW` + the OpenXR `XrNegotiateLoaderRuntimeInterface`, which gives us an **in-process compositor** (not `openxr_loader.dll` + IPC). DPI awareness is set to per-monitor at module startup so the backbuffer uses physical pixels.
+- **macOS** loads the runtime `.so`/`.dylib` via `dlopen` and binds via `XR_EXT_cocoa_window_binding`. Current code is stubbed on Mac for the compositor path; validation tracked in [TODO.md](./TODO.md) §5.
+- **Android** shares the runtime-loading pattern but validation is also pending; tracked in [TODO.md](./TODO.md) §5.
+
+## Common gotchas for agents
+
+- **Don't re-introduce "dual-path" framing.** If a task requires different behavior on Mac, use `#if PLATFORM_MAC` inside session/compositor, not a product flag.
+- **Don't reach into `FDisplayXRSession` from components.** Use `FDisplayXRPlatform`. The session is thread-touchpoint-sensitive (compositor thread, game, render).
+- **Don't block the compositor thread.** It must stay responsive to runtime vsync. Handshake is event-based; game/render work happens elsewhere.
+- **Editor PIE ≠ standalone.** UE does not call `FDisplayXRDevice::UpdateViewport()` in PIE today — that's the whole point of the in-flight [EditorPreviewNative](./EditorPreviewNative.md) work.

--- a/Docs/DisplayXR/MacSetup.md
+++ b/Docs/DisplayXR/MacSetup.md
@@ -1,147 +1,81 @@
-# macOS Setup Guide
+# macOS Setup
+
+Mac runs the same [Architecture](./Architecture.md) as Windows — one unified `FDisplayXRSession` loaded via `dlopen`. This doc covers the Mac-specific quirks the QuickStart doesn't handle.
+
+For the generic install-and-go flow, start with [QuickStart.md](./QuickStart.md) and come back here for the Mac-specific bits.
 
 ## Prerequisites
 
-- UE 5.7+ installed via Epic Games Launcher
+- Unreal Engine 5.3+ installed via Epic Games Launcher
 - Xcode (for C++ plugin compilation)
-- DisplayXR runtime installed (either from package or built from source)
+- DisplayXR runtime installed (either from a package or built from source — see [openxr-3d-display](https://github.com/dfattal/openxr-3d-display))
 
-## Platform Architecture
+## Mac-specific quirk 1: no UE OpenXR plugin on Mac
 
-Unreal's OpenXR plugin (`OpenXRHMD`) **does not ship on macOS**. Therefore, the DisplayXR plugin uses a different code path on Mac:
+Unreal's `OpenXR` plugin **does not ship on macOS**. Builds that depend on it will fail with `OpenXRHMD module not found`.
 
-| | Windows/Android | macOS |
-|---|---|---|
-| **OpenXR integration** | `IOpenXRExtensionPlugin` hooks into Unreal's `FOpenXRHMD` | `FDisplayXRDirectSession` loads OpenXR runtime directly via `dlopen` |
-| **Stereo injection** | `InsertOpenXRAPILayer()` hooks `xrLocateViews` | `FDisplayXRSceneViewExtension : FSceneViewExtensionBase` overrides camera |
-| **Runtime discovery** | Unreal's OpenXR loader handles it | Plugin loads `libopenxr_displayxr.so` directly |
-| **Compile flag** | `DISPLAYXR_USE_UNREAL_OPENXR=1` | `DISPLAYXR_USE_UNREAL_OPENXR=0` |
+This is not a problem for DisplayXR directly — the current `DisplayXR.uplugin` only depends on `XRBase`, which is available on Mac. **If you see a `.uplugin` anywhere that lists `OpenXR` as a plugin dependency, it's stale — delete the entry on Mac.**
 
-The Kooima math, components, rig manager, Blueprint API, and materials module are **identical** across platforms. Only the rendering injection point differs.
+## Mac-specific quirk 2: set DisplayXR as the active OpenXR runtime
 
-## Step 1: Set DisplayXR as Active OpenXR Runtime
-
-The system active runtime file currently points to SRMonado. Switch it to DisplayXR:
+Unlike Windows (where the registry entry is usually set by the runtime installer), Mac's active-runtime manifest lives in a plain JSON file. You may need to point it at DisplayXR:
 
 ```bash
-# Check current active runtime
+# See what's currently active
 cat /etc/xdg/openxr/1/active_runtime.json
 
-# Option A: Point to installed DisplayXR runtime
+# Option A — point to an installed DisplayXR runtime
 sudo cp /usr/local/share/openxr/1/openxr_displayxr.json /etc/xdg/openxr/1/active_runtime.json
 
-# Option B: Point to development build
+# Option B — write it inline (useful for a dev build)
 sudo tee /etc/xdg/openxr/1/active_runtime.json << 'EOF'
 {
     "file_format_version": "1.0.0",
     "runtime": {
         "name": "DisplayXR",
-        "library_path": "/usr/local/lib/libopenxr_displayxr.so"
+        "library_path": "/usr/local/lib/libopenxr_displayxr.dylib"
     }
 }
 EOF
 
-# Option C: Use environment variable (per-process, no sudo needed)
+# Option C — per-process override, no sudo needed
 export XR_RUNTIME_JSON=/usr/local/share/openxr/1/openxr_displayxr.json
 ```
 
-Verify the runtime library exists:
-```bash
-ls -la /usr/local/lib/libopenxr_displayxr.so
-```
-
-## Step 2: Create a UE C++ Project
-
-1. Open Unreal Editor 5.7
-2. Create a new project: **Games > Blank > C++** (not Blueprint)
-3. Name it (e.g., "DisplayXRTest")
-4. Wait for project creation to complete
-5. Close the editor
-
-## Step 3: Install the Plugin
+Verify the runtime library is readable:
 
 ```bash
-cd /path/to/DisplayXRTest/Plugins
-mkdir DisplayXR
-
-# Copy plugin files from the DisplayXR repo
-cp /path/to/displayxr-unreal/DisplayXR.uplugin DisplayXR/
-cp -r /path/to/displayxr-unreal/Source/DisplayXRCore DisplayXR/Source/
-cp -r /path/to/displayxr-unreal/Source/DisplayXRMaterials DisplayXR/Source/
-cp -r /path/to/displayxr-unreal/Source/DisplayXREditor DisplayXR/Source/
+ls -la /usr/local/lib/libopenxr_displayxr.dylib
 ```
 
-## Step 4: Disable the OpenXR Plugin Dependency (Mac Only)
+## Mac-specific quirk 3: graphics binding
 
-Edit `DisplayXR/DisplayXR.uplugin` and remove or disable the OpenXR plugin dependency on Mac:
+On Windows the session uses `XrGraphicsBindingD3D12KHR`. On Mac it uses `XR_EXT_cocoa_window_binding` via Metal. The session handles this internally via `#if PLATFORM_MAC` — you don't set any compile flag. If you're touching session code and need the Mac path, look for `PLATFORM_MAC || PLATFORM_LINUX` branches in `DisplayXRSession.cpp`.
 
-The plugin descriptor has `"Plugins": [{"Name": "OpenXR", "Enabled": true}]`. On Mac, this will fail because the OpenXR plugin doesn't exist. Either:
+## Install + build
 
-**Option A:** Remove the OpenXR dependency (safest for Mac-only testing):
-```json
-"Plugins": []
-```
+Once the quirks above are sorted, install the plugin like on any platform:
 
-**Option B:** Make it platform-conditional (requires testing).
+1. Create a UE 5.3+ **C++** project (Blueprint-only can't compile plugins).
+2. Close the editor.
+3. Clone the repo into `Plugins/DisplayXR/`:
+   ```bash
+   cd <YourProject>
+   mkdir -p Plugins
+   git clone https://github.com/DisplayXR/displayxr-unreal.git Plugins/DisplayXR
+   ```
+4. Regenerate the Xcode project and build, or double-click the `.uproject` and let UE compile it.
 
-## Step 5: Build and Launch
-
-Double-click the `.uproject` file. Unreal will detect the plugin and compile it via Xcode.
-
-Check Output Log for:
-```
-DisplayXR: Core module started (direct OpenXR session path)
-DisplayXR Direct: Loaded OpenXR from /usr/local/lib/libopenxr_displayxr.so
-DisplayXR Direct: Instance created, SystemId=...
-DisplayXR Direct: Display X.XXX x X.XXX m, XXXX x XXXX px
-DisplayXR Direct: Session created
-DisplayXR Direct: Session running
-```
-
-## Step 6: Test
-
-1. Add a Camera Actor to the scene
-2. Add a `DisplayXR Camera` component to it (from the DisplayXR category)
-3. Adjust IpdFactor, ParallaxFactor, InvConvergenceDistance
-4. The editor viewport should show Kooima-adjusted perspective
-
-## How the Mac Path Works
-
-```
-Engine Startup:
-  FDisplayXRCoreModule::StartupModule()
-    → Creates FDisplayXRDirectSession
-    → dlopen("libopenxr_displayxr.so")
-    → xrCreateInstance() with XR_EXT_display_info + XR_EXT_cocoa_window_binding
-    → xrGetSystemProperties() → queries display info
-    → xrCreateSession() with Cocoa binding
-    → Registers FDisplayXRSceneViewExtension
-
-Each Frame:
-  FDisplayXRDirectSession::Tick()
-    → xrPollEvent (handle session state changes)
-    → xrLocateViews (get raw eye positions)
-    → camera3d/display3d_compute_views (Kooima projection)
-    → Store stereo matrices in double buffer
-
-  FDisplayXRSceneViewExtension::SetupViewPoint()
-    → Read eye positions from direct session
-    → Apply center-eye offset to editor camera
-
-  FDisplayXRSceneViewExtension::SetupView()
-    → Read Kooima projection matrices from direct session
-    → Override camera projection matrix
-
-  UDisplayXRCamera/Display::TickComponent()
-    → Push tunables via FDisplayXRPlatform (routes to direct session)
-```
+Then see [QuickStart.md](./QuickStart.md) §3–5 for rig setup and verification.
 
 ## Troubleshooting
 
-**"Failed to load OpenXR loader"**: The runtime library wasn't found. Check that `/usr/local/lib/libopenxr_displayxr.so` exists. If using a dev build, set `XR_RUNTIME_JSON` environment variable before launching UE.
+- **`Failed to load OpenXR loader`** — runtime library wasn't found. Check the `library_path` in `/etc/xdg/openxr/1/active_runtime.json` against what's actually on disk, or set `XR_RUNTIME_JSON` before launching UE.
+- **`xrCreateInstance failed`** — runtime loaded but couldn't initialize. Check the 3D display is connected and its driver is running.
+- **`xrCreateSession failed`** — instance created but session failed. This can happen if no display is connected — the plugin still provides display info but won't track eyes.
+- **Build error: `OpenXRHMD module not found`** — the `.uplugin` still has an `OpenXR` dependency (see quirk 1 above). Pull latest or remove the entry manually.
+- **`Session initialized` but rendering is 2D** — the HMD plugin priority bump didn't win. Ensure `DisplayXRCore` is actually loading (`PostConfigInit`). On Mac the compositor path is still being validated (tracked in [TODO.md](./TODO.md) §5); Mac may render in 2D by design until that lands.
 
-**"xrCreateInstance failed"**: The runtime loaded but couldn't initialize. Check that the 3D display is connected and its driver is running.
+## Status
 
-**"xrCreateSession failed"**: Instance created but session failed. This can happen if no display is connected — the plugin will still provide display info but won't track eyes.
-
-**Build error: "OpenXRHMD module not found"**: The `.uplugin` still has the OpenXR dependency. Remove it for Mac builds (see Step 4).
+Mac validation (end-to-end session + compositor) is tracked in [TODO.md](./TODO.md) §5 under "Platform coverage". The architecture works on Mac in principle; the last-mile testing is pending.

--- a/Docs/DisplayXR/QuickStart.md
+++ b/Docs/DisplayXR/QuickStart.md
@@ -1,0 +1,78 @@
+# Quick Start
+
+Install the runtime → install the plugin → open a UE project → press Play. ~10 minutes.
+
+For Mac-specific quirks (OpenXR active-runtime switching, no UE OpenXR plugin), also read [MacSetup.md](./MacSetup.md).
+
+## 1. Install the DisplayXR OpenXR runtime
+
+The plugin is useless without the runtime. Install from [openxr-3d-display](https://github.com/dfattal/openxr-3d-display) — that repo's README has the current install steps per platform.
+
+Verify the runtime is discoverable:
+
+```
+# Windows
+reg query "HKLM\SOFTWARE\Khronos\OpenXR\1" /v ActiveRuntime
+
+# macOS / Linux
+cat /etc/xdg/openxr/1/active_runtime.json
+```
+
+Either should point to a `openxr_displayxr.json` manifest and a corresponding `.dll` / `.so` / `.dylib`.
+
+## 2. Set up a UE project
+
+1. Create a new Unreal Engine 5.3+ C++ project (Blueprint-only projects can't compile plugins — use C++ Blank).
+2. Close the editor.
+3. Clone this repo into `Plugins/DisplayXR/`:
+   ```
+   cd <YourProject>
+   mkdir -p Plugins
+   git clone https://github.com/DisplayXR/displayxr-unreal.git Plugins/DisplayXR
+   ```
+4. Right-click the `.uproject` → **Generate Visual Studio project files** (Windows) or regenerate Xcode project (Mac).
+5. Build from your IDE, or double-click the `.uproject` to let UE compile it.
+
+On first launch the editor will report `DisplayXR: Session initialized` in the Output Log. If it reports `Failed to initialize session`, the runtime install from step 1 didn't take — fix that before going further.
+
+## 3. Set up a rig in the scene
+
+Simplest camera-centric rig:
+
+1. Open any level with a `Pawn` or create one via **Blueprint > Pawn**.
+2. Add a `Camera` component.
+3. Tick **Use Pawn Control Rotation** on the camera (required — see [DisplayRigSetup.md](./DisplayRigSetup.md)).
+4. Add a **DisplayXR Camera** component (under *DisplayXR* category) to the same pawn.
+5. Adjust `IpdFactor`, `ParallaxFactor`, `ConvergenceDistance` if you want — defaults work.
+6. Set this pawn as the level's **Default Pawn Class** via Game Mode.
+
+For display-centric rigs (virtual display placed in the scene rather than on the camera), use a **DisplayXR Display** component instead. See [DisplayRigSetup.md](./DisplayRigSetup.md).
+
+## 4. Press Play
+
+Click Play in the editor. The current editor preview uses `SceneCapture2D` → a separate native 3D window (see [EditorPreview.md](./EditorPreview.md); native-XR preview is in-flight, see [EditorPreviewNative.md](./EditorPreviewNative.md)).
+
+For the most faithful output, launch as a standalone game (**Play > Standalone Game** or build via `Scripts/PackagePlugin.bat`). In game mode the compositor path is fully active and the runtime drives the 3D display directly.
+
+## 5. Verify the pipeline
+
+In the Output Log look for:
+
+```
+DisplayXR: Session initialized
+DisplayXR Session: Instance created, SystemId=...
+DisplayXR Session: Display X.XXX x X.XXX m, XXXX x XXXX px
+DisplayXR Session: Session created
+DisplayXR: Tracking system created
+```
+
+If eye tracking is working you'll also see the 3D display switch to 3D mode and the image change as you move your head.
+
+## Troubleshooting
+
+- **`Failed to initialize session`** — runtime not installed or not the active OpenXR runtime. Re-verify step 1.
+- **Game builds but renders in 2D** — `DisplayXRCore` HMD plugin priority didn't win. Check that `OpenXRHMD` isn't being forced active in `Engine/Config/DefaultEngine.ini`.
+- **Everything loads but the 3D display stays in 2D mode** — call `RequestDisplayMode(true)` via Blueprint or ensure a `DisplayXR Camera` / `DisplayXR Display` component is in the scene and active.
+- **Mac build fails with `OpenXRHMD module not found`** — you have a stale `.uplugin`. Current `DisplayXR.uplugin` depends only on `XRBase`, not `OpenXR`. Pull latest.
+
+For packaging, rig tuning, and architecture background, see the [documentation index](./README.md).

--- a/Docs/DisplayXR/README.md
+++ b/Docs/DisplayXR/README.md
@@ -2,29 +2,28 @@
 
 Unreal Engine integration with the DisplayXR OpenXR runtime for eye-tracked 3D light field displays.
 
+> **New here?** Start with the [Quick Start](./QuickStart.md) guide. Then read [Architecture.md](./Architecture.md) for the mental model.
+
 ## Quick Links
 
-- [Atlas Handoff](./AtlasHandoff.md) — How UE renders directly into the OpenXR swapchain (zero-copy): single-device D3D12, `AllocateRenderTargetTextures`+`AcquireColorTexture`, per-frame Acquire/Release handshake
-- [Compositor Integration](./CompositorIntegration.md) — Original Phase 2 planning doc (historical)
+### Getting started
+- [Quick Start](./QuickStart.md) — Install runtime → install plugin → open a project → press Play
 - [Display Rig Setup](./DisplayRigSetup.md) — How to set up the pawn/camera rig for stereo 3D (camera rotation, input, display-centric vs camera-centric)
+- [Mac Setup](./MacSetup.md) — macOS-specific quirks (OpenXR active-runtime switching, `.uplugin` dependencies)
+
+### Architecture
+- [Architecture](./Architecture.md) — One-page class hierarchy, ownership, per-frame data flow
+- [Atlas Handoff](./AtlasHandoff.md) — Zero-copy UE → OpenXR swapchain (single-device D3D12, Acquire/Release handshake)
 - [Eye Tracking](./EyeTracking.md) — Parallax pipeline: `xrLocateViews` → Kooima → per-view projection, coordinate conventions
+- [ADRs](./adr/) — Decision records for load-bearing choices (direct runtime loading, zero-copy atlas, UE-native projection)
+
+### Editor preview
 - [Editor Preview](./EditorPreview.md) — Current `SceneCapture2D`-based preview strategy, Unity vs Unreal differences
 - [Editor Preview: Native XR Path](./EditorPreviewNative.md) — In-flight plan to replace the current preview with a native `FDisplayXRDevice` → PIE hookup (see also the [agent prompt](./EditorPreviewNative-AgentPrompt.md))
-- [Mac Setup](./MacSetup.md) — macOS-specific setup, direct OpenXR session, scene view extension
+
+### Historical / planning
+- [Compositor Integration](./CompositorIntegration.md) — Prior "separate device + IPC" compositor design (superseded by the single-device path; kept for context)
 - [TODO](./TODO.md) — Outstanding work, parity with the Unity sibling, in-flight branches
-
-## Platform Architecture
-
-The plugin has **two code paths** selected at compile time:
-
-| | Windows / Android | macOS |
-|---|---|---|
-| **How** | `IOpenXRExtensionPlugin` hooks into UE's `FOpenXRHMD` | `FDisplayXRDirectSession` loads runtime via `dlopen` |
-| **Stereo injection** | `InsertOpenXRAPILayer` hooks `xrLocateViews` | `FSceneViewExtensionBase` overrides camera projection |
-| **Compile flag** | `DISPLAYXR_USE_UNREAL_OPENXR=1` | `DISPLAYXR_USE_UNREAL_OPENXR=0` |
-| **Why different** | UE ships OpenXR plugin on Windows/Android | UE does **not** ship OpenXR plugin on macOS |
-
-Everything else is shared: components, rig manager, Kooima C libraries, Blueprint API, materials module. The `FDisplayXRPlatform` abstraction routes calls to the active backend.
 
 ## Reference Repositories
 

--- a/Docs/DisplayXR/TODO.md
+++ b/Docs/DisplayXR/TODO.md
@@ -45,8 +45,8 @@ Unity sibling has a more mature docs tree. Bring Unreal up to parity so users ca
 
 ## 5. Platform coverage
 
-- **macOS path validation** — `DISPLAYXR_USE_UNREAL_OPENXR=0`, direct session via `FDisplayXRDirectSession`. End-to-end smoke test on a supported display.
-- **Android path validation** — OpenXR hook on current DisplayXR runtime. Vulkan backend.
+- **macOS path validation** — end-to-end smoke test of the unified `FDisplayXRSession` (Metal graphics binding, Cocoa window binding) on a supported display. See [MacSetup.md](./MacSetup.md).
+- **Android path validation** — unified session on Android (Vulkan graphics binding).
 - **UE version sweep** — currently targets UE 5.3+. Confirm 5.6 works; track 5.7 pre-release.
 
 ---

--- a/Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md
+++ b/Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md
@@ -1,0 +1,40 @@
+# ADR-001 — Direct OpenXR runtime loading
+
+**Status:** Accepted
+**Date:** 2026-04
+
+## Context
+
+Early drafts of this plugin envisioned a dual-path integration: on Windows/Android we'd register as an `IOpenXRExtensionPlugin` extending UE's `FOpenXRHMD`; on macOS we'd bypass UE's OpenXR entirely and drive a direct session because UE does not ship its OpenXR plugin on Mac.
+
+That split is still visible in stale docs. The actual code consolidated on one approach.
+
+## Decision
+
+`FDisplayXRSession` loads the DisplayXR OpenXR runtime directly on every platform:
+
+- Windows: `LoadLibraryW` on the runtime DLL and use `XrNegotiateLoaderRuntimeInterface` to bind. This gives an **in-process** runtime (the runtime's compositor lives in the UE process) rather than going through `openxr_loader.dll` → `DisplayXRClient.dll` IPC.
+- macOS / Linux: `dlopen` on the runtime `.so` / `.dylib`.
+
+UE's OpenXR plugin is **not** a dependency. `DisplayXR.uplugin` declares only `XRBase`. `FDisplayXRCoreModule` implements `IHeadMountedDisplayModule` and bumps its own HMD plugin priority +10 above `OpenXRHMD` / `SteamVR` so UE's HMD discovery picks DisplayXR first.
+
+Platform differences (DLL loading, window binding, graphics binding) live inside session and compositor code behind `#if PLATFORM_WINDOWS / PLATFORM_MAC / PLATFORM_LINUX`. There is no product-level compile flag.
+
+## Alternatives considered
+
+1. **`IOpenXRExtensionPlugin` on top of UE's `FOpenXRHMD`.** Rejected: it would force us to inherit UE's session lifecycle, its swapchain choices, and its frame pacing. The custom compositor path needs control over `xrWaitFrame` / `xrBeginFrame` / `xrEndFrame` on a dedicated thread. Extension-plugin hooks are too narrow.
+2. **Dual implementation split by compile flag (`DISPLAYXR_USE_UNREAL_OPENXR`).** Attempted in early planning, never materialized in code. Would have meant carrying two entire integrations for no real win once the runtime became cross-platform.
+3. **Load via `openxr_loader.dll` (the Khronos loader).** Rejected on Windows because it routes to an IPC client (`DisplayXRClient.dll`). We want the in-process compositor so the runtime can weave directly against our D3D12 device without cross-process texture sharing.
+
+## Consequences
+
+- One unified session class. Easier to reason about and to change.
+- UE's `FOpenXRHMD` never enters the picture. Any agent thinking "extend UE's OpenXR plugin" is on the wrong track.
+- Runtime installation is our responsibility — we don't piggyback on whatever runtime UE's OpenXR chose.
+- Platform-conditional code lives inside session/compositor, not spread across two class trees.
+- HMD plugin priority must stay higher than `OpenXRHMD`/`SteamVR`. If someone enables those alongside DisplayXR, the +10 bump in `FDisplayXRCoreModule::StartupModule()` keeps us active.
+
+## Related
+
+- [Architecture.md](../Architecture.md) — overall structure
+- [AtlasHandoff.md](../AtlasHandoff.md) — consequence: UE renders into our swapchain, not UE's

--- a/Docs/DisplayXR/adr/ADR-002-zero-copy-atlas-handoff.md
+++ b/Docs/DisplayXR/adr/ADR-002-zero-copy-atlas-handoff.md
@@ -1,0 +1,43 @@
+# ADR-002 — Zero-copy atlas handoff via single D3D12 device
+
+**Status:** Accepted
+**Date:** 2026-04
+
+## Context
+
+The DisplayXR runtime wants an OpenXR swapchain it can weave against. UE has its own render target pipeline. The naive integration is: let UE render into a UE-owned render target, then copy to the OpenXR swapchain image each frame. That works but:
+
+- Burns bandwidth on a 4K+ backbuffer every frame.
+- Needs synchronization we can get wrong (flicker, torn frames).
+- On cross-process runtimes, the copy has to go through shared-handle plumbing and fences — even more friction.
+
+We did build an intermediate version of that (separate device + shared texture + cross-process copy) before landing the current design. It worked but was complex and fragile — documented in [CompositorIntegration.md](../CompositorIntegration.md) as historical context.
+
+## Decision
+
+UE renders **directly** into the OpenXR swapchain. The flow:
+
+1. `FDisplayXRCompositor::Initialize()` takes UE's D3D12 device and command queue (borrowed, not owned) plus a dedicated **runtime queue** created on UE's device.
+2. `xrCreateSession` uses the runtime queue as its `XrGraphicsBindingD3D12KHR`. UE and the runtime share one D3D12 device — no cross-device copy, no shared handles.
+3. `xrCreateSwapchain` with UE's preferred format. The resulting `ID3D12Resource*` images are wrapped as `FRHITexture` via the D3D12 RHI's external-resource wrap path.
+4. UE's `AllocateRenderTargetTexture` returns a wrapped swapchain texture from the current pool. UE's renderer writes directly into it.
+5. A dedicated compositor thread runs the frame handshake (`xrWaitFrame` / `xrBeginFrame` / `xrEndFrame`) off UE's game/render threads, coordinated via two `FEvent`s.
+
+## Alternatives considered
+
+1. **Copy each frame.** Rejected for bandwidth and sync reasons above.
+2. **Separate D3D12 device for the runtime, cross-device shared textures.** Built as an intermediate. Dropped once the single-device path was proven — it's strictly simpler and faster.
+3. **Let UE's `FOpenXRHMD` own the swapchain.** Blocked by ADR-001 (we don't use UE's OpenXR plugin).
+4. **Run the compositor on UE's render thread.** Rejected: `xrWaitFrame` blocks on runtime vsync and would stall UE's frame timing. The dedicated thread keeps the runtime pacing independent of UE's scene work.
+
+## Consequences
+
+- No per-frame copies. UE's scene output *is* the OpenXR submission.
+- Requires a D3D12 path; the zero-copy version is Windows-only. Mac/Metal uses a different handoff strategy (tracked in [TODO.md](../TODO.md)).
+- The compositor thread is an extra thread you need to reason about when touching session state — the session's tunables and view config are already double-buffered with atomic index swaps for that reason.
+- Format and extent must be negotiated with both UE's preferred backbuffer format and the runtime's supported list. Failure mode: runtime rejects the swapchain create. Detailed in [AtlasHandoff.md](../AtlasHandoff.md).
+
+## Related
+
+- [AtlasHandoff.md](../AtlasHandoff.md) — implementation detail of the wrap + handshake
+- [CompositorIntegration.md](../CompositorIntegration.md) — prior "separate device + IPC" history

--- a/Docs/DisplayXR/adr/ADR-003-ue-native-off-axis-projection.md
+++ b/Docs/DisplayXR/adr/ADR-003-ue-native-off-axis-projection.md
@@ -1,0 +1,46 @@
+# ADR-003 — UE-native off-axis projection instead of Kooima's `projection_matrix[16]`
+
+**Status:** Accepted
+**Date:** 2026-04
+
+## Context
+
+The Kooima projection library (shared with [displayxr-unity](https://github.com/DisplayXR/displayxr-unity)) computes everything we need for asymmetric off-axis stereo: per-eye position, per-eye projection matrix, per-eye view matrix. The obvious integration is: take Kooima's 4×4 `projection_matrix[16]` and hand it to UE's stereo rendering pipeline.
+
+We tried that. It fought UE at every step.
+
+Kooima produces an OpenGL-convention projection matrix: column-major, right-handed, Z forward, depth `[-1, 1]`. UE uses row-major, left-handed, reverse-Z (`[1, 0]`). Every conversion we applied caused a subtle regression somewhere: inverted depth, flipped handedness in a post-process, broken planar reflections, etc.
+
+## Decision
+
+Consume Kooima's **eye positions** (the easy, convention-free output) and rebuild the projection matrix in UE's own convention via `CalculateOffAxisProjectionMatrix()` in `DisplayXRStereoMath.h`.
+
+The matrix is UE-native reverse-Z infinite-far-plane, matching what `FMinimalViewInfo::CalculateProjectionMatrix` would produce for an on-axis camera — just with the frustum offsets derived from the tracked eye position. Concretely:
+
+```cpp
+// Inputs: ViewportHalfSize (UE units, convergence plane half-extent)
+//         EyeLocation in UE local coords relative to screen center
+// Output: UE reverse-Z projection matrix, infinite far plane
+return AdjustProjectionMatrixForRHI(...);
+```
+
+Eye positions pass through `OpenXRPositionToUE(const XrVector3f&)` and `OpenXROrientationToUE(const XrQuaternionf&)` helpers in `DisplayXRStereoMath.h` to handle the axis swap (OpenXR +Z toward viewer → UE −X backward, OpenXR +X/+Y → UE +Y/+Z).
+
+## Alternatives considered
+
+1. **Use Kooima's `projection_matrix[16]` directly.** Produced visible depth/reflection artifacts. Every workaround we tried broke something else.
+2. **Convert Kooima matrix to UE convention at load time.** Converting a 4×4 matrix between coordinate systems is straightforward *if both sides agree on what the matrix represents semantically* — but UE's `FViewInfo` wants a matrix that plays nicely with reverse-Z, TAA jitter, and infinite-far-plane assumptions. We'd have been re-deriving UE's projection in a less auditable way.
+3. **Write a shared engine-agnostic off-axis helper.** Possible but extra moving parts for no gain — Unreal and Unity already have mature per-engine projection builders, and axis/unit conversion happens at the boundary anyway.
+
+## Consequences
+
+- Only **eye positions** cross the Kooima boundary. Handedness, units, and Z-range convention live inside the engine binding, not the shared math.
+- `DisplayXRStereoMath.h` owns the UE-side projection. Any change to UE's projection convention (e.g. if Epic changes reverse-Z defaults) touches one helper.
+- Keeps the Kooima C files engine-agnostic so they stay in sync with Unity's copy.
+- Slightly more code on the UE side (rebuilding the matrix) vs. just taking Kooima's output — acceptable for the robustness gain.
+
+## Related
+
+- `Source/DisplayXRCore/Private/DisplayXRStereoMath.h` — the matrix + eye-offset helpers
+- `Source/DisplayXRCore/Private/Native/camera3d_view.c` / `display3d_view.c` — Kooima source (shared with Unity)
+- [EyeTracking.md](../EyeTracking.md) — the full `xrLocateViews` → Kooima → UE pipeline

--- a/Docs/DisplayXR/adr/README.md
+++ b/Docs/DisplayXR/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+Short decision logs for load-bearing choices in the DisplayXR Unreal plugin. Each ADR captures the context, the decision, the alternatives considered, and the consequences — so an agent picking up new work doesn't re-propose the paths we already ruled out.
+
+## Index
+
+- [ADR-001 — Direct OpenXR runtime loading (no UE OpenXR plugin)](./ADR-001-direct-runtime-loading.md)
+- [ADR-002 — Zero-copy atlas handoff via single D3D12 device](./ADR-002-zero-copy-atlas-handoff.md)
+- [ADR-003 — UE-native off-axis projection instead of Kooima's `projection_matrix[16]`](./ADR-003-ue-native-off-axis-projection.md)
+
+## When to write a new ADR
+
+- A decision is non-obvious and another agent would plausibly re-propose the alternative.
+- The decision ties together code + docs + downstream behavior in a way that's hard to reconstruct from git history.
+- You want to make "why not X?" easy to answer without re-running the investigation.
+
+Keep ADRs short (under a page). Status, context, decision, alternatives considered, consequences. If it grows past a page, break it into a design doc and leave the ADR as the index.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The plugin hooks into Unreal's OpenXR pipeline to provide:
 - **Zero-copy atlas handoff** — UE renders directly into the OpenXR swapchain (see [AtlasHandoff](Docs/DisplayXR/AtlasHandoff.md))
 - **Editor preview** — a standalone OpenXR session in the editor so you can see stereo output without running PIE (see [EditorPreview](Docs/DisplayXR/EditorPreview.md))
 
-Two code paths are selected at compile time — `IOpenXRExtensionPlugin` hook on Windows/Android, direct OpenXR session on macOS. Everything else (components, rig manager, Kooima C libraries, Blueprint API, materials module) is shared.
+One unified session loads the DisplayXR OpenXR runtime directly on every platform; UE's `OpenXR` plugin is **not** a dependency. Platform differences (Windows D3D12, macOS Metal, Android Vulkan) live inside the session and compositor, not in a product-level compile flag. See [Architecture.md](Docs/DisplayXR/Architecture.md) for the full picture.
 
 ## Requirements
 
@@ -71,12 +71,16 @@ For per-project builds, use UAT directly (see `Scripts/PackageApp.py` for a refe
 
 In-depth docs live in [Docs/DisplayXR/](Docs/DisplayXR/):
 
-- [AtlasHandoff](Docs/DisplayXR/AtlasHandoff.md) — zero-copy UE→OpenXR swapchain pipeline
+- [QuickStart](Docs/DisplayXR/QuickStart.md) — install runtime → install plugin → press Play
+- [Architecture](Docs/DisplayXR/Architecture.md) — one-page class hierarchy, ownership, per-frame flow
+- [AtlasHandoff](Docs/DisplayXR/AtlasHandoff.md) — zero-copy UE → OpenXR swapchain pipeline
 - [DisplayRigSetup](Docs/DisplayXR/DisplayRigSetup.md) — pawn/camera rig configuration, input, rig modes
-- [EditorPreview](Docs/DisplayXR/EditorPreview.md) — standalone preview session, Unity vs Unreal differences
+- [EditorPreview](Docs/DisplayXR/EditorPreview.md) — current `SceneCapture2D`-based preview
+- [EditorPreviewNative](Docs/DisplayXR/EditorPreviewNative.md) — in-flight plan for native `FDisplayXRDevice` → PIE preview
 - [EyeTracking](Docs/DisplayXR/EyeTracking.md) — `xrLocateViews` → Kooima → per-view projection pipeline
-- [MacSetup](Docs/DisplayXR/MacSetup.md) — macOS-specific setup, direct OpenXR session
-- [CompositorIntegration](Docs/DisplayXR/CompositorIntegration.md) — historical planning doc for the compositor thread design
+- [MacSetup](Docs/DisplayXR/MacSetup.md) — macOS-specific setup quirks
+- [CompositorIntegration](Docs/DisplayXR/CompositorIntegration.md) — prior compositor design (historical)
+- [ADRs](Docs/DisplayXR/adr/) — decision records for load-bearing architectural choices
 - [TODO](Docs/DisplayXR/TODO.md) — outstanding work, parity items, in-flight branches
 
 ## Related Repositories


### PR DESCRIPTION
## Summary

Tackles the four doc items flagged in the \"adequacy for devs/agents\" review:

1. **Architecture.md** (new) — one-page class hierarchy, per-frame data flow, module map. Anchor for agents needing a mental model before touching session/device/compositor code.
2. **QuickStart.md** (new) — install runtime → install plugin → press Play in ~10 min.
3. **ADR-001/002/003** (new) — decision records for direct runtime loading, zero-copy atlas handoff, and UE-native off-axis projection. Stops agents from re-proposing the rejected alternatives.
4. **Verified \`DISPLAYXR_USE_UNREAL_OPENXR\`** — it was a **phantom flag**. Only referenced in docs, never defined in source or \`Build.cs\`. Platform selection is \`#if PLATFORM_WINDOWS / PLATFORM_MAC / PLATFORM_LINUX\` inside \`FDisplayXRSession\` and \`FDisplayXRCompositor\`. Corrected every stale reference.

## Corrected stale docs

Several docs described a dual-path architecture (\`IOpenXRExtensionPlugin\` on Win/Android vs \`FDisplayXRDirectSession\` on Mac, toggled by \`DISPLAYXR_USE_UNREAL_OPENXR\`) that **never existed in code**. The actual architecture is one unified \`FDisplayXRSession\` that loads the DisplayXR OpenXR runtime directly on every platform. Fixes:

- \`CLAUDE.md\` — \"Dual-Path OpenXR Integration\" section → unified session
- \`README.md\` — drop \"two code paths at compile time\" line
- \`Docs/DisplayXR/README.md\` — drop Platform Architecture dual-path table, restructure into sections
- \`Docs/DisplayXR/MacSetup.md\` — rewrite; removes references to \`FDisplayXRDirectSession\`, \`FDisplayXRSceneViewExtension\`, and the phantom flag. Now focuses on actual Mac quirks (active-runtime manifest, no UE OpenXR plugin on Mac)
- \`Docs/DisplayXR/TODO.md\` — drop \`DISPLAYXR_USE_UNREAL_OPENXR=0\` from the macOS validation bullet

## Files

**Added**
- \`Docs/DisplayXR/Architecture.md\`
- \`Docs/DisplayXR/QuickStart.md\`
- \`Docs/DisplayXR/adr/README.md\`
- \`Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md\`
- \`Docs/DisplayXR/adr/ADR-002-zero-copy-atlas-handoff.md\`
- \`Docs/DisplayXR/adr/ADR-003-ue-native-off-axis-projection.md\`

**Modified**
- \`CLAUDE.md\`
- \`README.md\`
- \`Docs/DisplayXR/README.md\`
- \`Docs/DisplayXR/MacSetup.md\`
- \`Docs/DisplayXR/TODO.md\`

## Test plan

- [ ] \`lint.yml\` passes all three checks
- [ ] Manual: all internal links resolve
- [ ] Manual: Architecture.md accurately describes the actual code (see verification note below)

## Verification note on the phantom flag

\`\`\`
$ grep -rniI --exclude-dir=.git \"DISPLAYXR_USE_UNREAL_OPENXR\" .
# Only matches are in docs (now corrected); zero matches in Source/
\`\`\`

\`FDisplayXRSession.h\` comment explicitly states: \"Replaces both FDisplayXRExtensionPlugin (Windows/Android OpenXR hook path) and FDisplayXRDirectSession (Mac direct path) with a single unified session.\" That comment is the ground truth; the stale docs missed the memo.