### PR TITLE
docs: revise TODO to reflect shipped work

### DIFF
--- a/Docs/DisplayXR/TODO.md
+++ b/Docs/DisplayXR/TODO.md
@@ -14,28 +14,33 @@ Replace the current `SceneCapture2D`-based editor preview with a `FDisplayXRDevi
 
 ---
 
-## 2. Missing design docs (referenced elsewhere)
+## 2. Parity with [displayxr-unity](https://github.com/DisplayXR/displayxr-unity)
 
-- `Architecture.md` — module layout, class hierarchy, data flow, dual-path design (UE OpenXR on Windows/Android vs direct session on macOS). Unity has `docs/architecture/` split into `hook-chain.md`, `kooima-pipeline.md`, `preview-session.md`. Match that split here.
-- `OpenXRIntegration.md` — `IOpenXRExtensionPlugin` hook, `xrLocateViews` interception, per-frame sequence diagram.
+The Unity sibling has a more mature docs tree. Bring Unreal up to parity so users can switch between plugins without surprises.
 
----
+### Done
+- ✅ Quick-start guide → [`QuickStart.md`](./QuickStart.md)
+- ✅ Single-page architecture doc → [`Architecture.md`](./Architecture.md)
+- ✅ First 3 ADRs (Unreal-specific: direct runtime loading, zero-copy atlas, UE-native off-axis projection) → [`adr/`](./adr/)
 
-## 3. Parity with [displayxr-unity](https://github.com/DisplayXR/displayxr-unity)
+### Still open
 
-Unity sibling has a more mature docs tree. Bring Unreal up to parity so users can switch between plugins without surprises.
-
-- **`docs/quick-start-guide.md`** — step-by-step: install → demo scene camera-centric → demo scene display-centric → editor test → Windows build → macOS build → cross-compile. Unity version is ~470 lines. Adapt for UE (uplugin install, Project Settings, Blueprint rig setup, UAT `BuildCookRun`).
 - **`CHANGELOG.md`** — Keep-a-Changelog format. Seed with `## [0.1.0]` summarizing the initial DisplayXR release.
-- **`Docs/DisplayXR/adr/`** — Unity has 6 ADRs covering deferred destruction, dual session, native preview window, camera-vs-display mode, multipass-forced, window-relative Kooima. Port the ones that apply to Unreal; write new ADRs where the UE port made different calls.
-- **`Docs/DisplayXR/architecture/`** — subfolder with `hook-chain.md` (UE: `IOpenXRExtensionPlugin` + `FSceneViewExtensionBase`), `kooima-pipeline.md` (shared C lib), `preview-session.md` (current + native XR preview plan).
-- **`Docs/DisplayXR/roadmap/`** — carry over Unity planning docs relevant to shared native code (`full-gfx-backends-refactor-plan.md`, `phase1-mac-finish.md`). Add UE-specific roadmap items.
-- **Top-level README restructure** — match Unity's TOC style, add a "New to the plugin?" callout block, link to a sibling `displayxr-unreal-test` minimal UE project (if/when one exists).
+- **Additional ADRs mapped from Unity's set** — Unity has 6 ADRs covering decisions that are likely to have Unreal-side analogues or counter-decisions. Write a matching Unreal ADR (or a "does not apply because X" stub) for each:
+  - Unity ADR-001 *deferred-destruction* — Unity-specific teardown ordering; check if UE's module shutdown path has the same trap.
+  - Unity ADR-002 *dual-session* — Unity runs two OpenXR sessions (game + preview). We also do this via `FDisplayXRPreviewSession`; capture the Unreal-side tradeoffs.
+  - Unity ADR-003 *native-preview-window* — Relevant to current `FDisplayXRPreviewSession`; describe the Unreal window-creation path.
+  - Unity ADR-004 *camera-vs-display-mode* — We ship both `UDisplayXRCamera` and `UDisplayXRDisplay`; record the selection criteria.
+  - Unity ADR-005 *multipass-forced* — UE has separate multipass/instanced/MMV stereo modes; document which we force and why.
+  - Unity ADR-006 *window-relative-kooima* — Relevant for display-centric math; record how the Unreal port handles window-rect vs monitor-rect.
+- **`Docs/DisplayXR/architecture/` subfolder** (optional depth docs) — Unity has `hook-chain.md`, `kooima-pipeline.md`, `preview-session.md`. Our current [`Architecture.md`](./Architecture.md) is one page; split if it grows past that. Kooima pipeline detail already lives in [`EyeTracking.md`](./EyeTracking.md); preview-session detail is split across [`EditorPreview.md`](./EditorPreview.md) and [`EditorPreviewNative.md`](./EditorPreviewNative.md).
+- **`Docs/DisplayXR/roadmap/`** — Unity has planning docs (`full-gfx-backends-refactor-plan.md`, `phase1-mac-finish.md`, etc.). Carry over the ones relevant to shared native code; add UE-specific roadmap items.
+- **Top-level README polish** — current [`README.md`](../../README.md) has a TOC and the "New here?" callout. Unity's README is richer (per-section screenshots, deployment, troubleshooting). Bring the density up once we have a companion test project to link from.
 - **Companion test project** — create `DisplayXR/displayxr-unreal-test` mirroring `DisplayXR/displayxr-unity-test`: a minimal UE project with this plugin preconfigured, two demo maps (camera-centric, display-centric), ready to open and hit Play.
 
 ---
 
-## 4. CI & release
+## 3. CI & release
 
 - **Real UE build in CI** — current `lint.yml` only does vendor-name + JSON/YAML checks. Full compile needs either a self-hosted runner with UE preinstalled or Epic's container registry (requires Epic account linkage). Matrix target: UE 5.3–5.6.
 - **Release workflow** — package `DisplayXR.uplugin` per UE version, upload to GitHub Releases. Replaces any prior internal upload flow.
@@ -43,7 +48,7 @@ Unity sibling has a more mature docs tree. Bring Unreal up to parity so users ca
 
 ---
 
-## 5. Platform coverage
+## 4. Platform coverage
 
 - **macOS path validation** — end-to-end smoke test of the unified `FDisplayXRSession` (Metal graphics binding, Cocoa window binding) on a supported display. See [MacSetup.md](./MacSetup.md).
 - **Android path validation** — unified session on Android (Vulkan graphics binding).
@@ -51,7 +56,7 @@ Unity sibling has a more mature docs tree. Bring Unreal up to parity so users ca
 
 ---
 
-## 6. Known issues / cleanup
+## 5. Known issues / cleanup
 
 - Kooima C libs (`camera3d_view.c/h`, `display3d_view.c/h`) are shared with `displayxr-unity`. Keep them engine-agnostic — no UE or Unity types — and sync changes both directions.
 - Some file-header years are `2025-2026`; new files should use `2026-` or extend the range as appropriate.


### PR DESCRIPTION
## Summary

Updates the TODO to match what's actually shipped after PR #3.

### Marked done
- QuickStart guide (\`QuickStart.md\`)
- Single-page architecture doc (\`Architecture.md\`)
- First 3 ADRs (Unreal-specific: direct runtime loading, zero-copy atlas, UE-native off-axis projection)

### Dropped entirely
- The old §2 \"Missing design docs\" section. \`Architecture.md\` covers what it described. The planned \`OpenXRIntegration.md\` is superseded by [ADR-001](./Docs/DisplayXR/adr/ADR-001-direct-runtime-loading.md) + \`Architecture.md\` since we don't use the \`IOpenXRExtensionPlugin\` pattern that doc was going to describe.

### Restructured
Unity parity section now has clear **Done** vs **Still open** subsections, and the ADR parity item is reframed as a mapping exercise: write a Unreal counterpart (or an explicit \"does not apply because X\" stub) for each of Unity's 6 ADRs.

## Test plan

- [ ] \`lint.yml\` passes
- [ ] Manual: TODO reads accurately against current repo state