### PR TITLE
add .github/CODEOWNERS — sole-reviewer auto-request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dfattal


### PR DESCRIPTION
1-line CODEOWNERS file (`* @dfattal`) so branch protection's `require_code_owner_reviews: true` (Phase 3 of the org-wide contributor-policy rollout) auto-requests @dfattal as the sole reviewer. Edit this file rather than the protection rule when onboarding co-maintainers.

Part of the rollout described in the runtime repo's Phase 1 PR (DisplayXR/displayxr-runtime#194).