### PR TITLE
ext: XR_EXT_display_info v13 ABI sync

### DIFF
--- a/Source/DisplayXRCore/Private/Native/displayxr_extensions.h
+++ b/Source/DisplayXRCore/Private/Native/displayxr_extensions.h
@@ -55,6 +55,14 @@ typedef struct XrDisplayRenderingModeInfoEXT {
     uint32_t tileRows;
     uint32_t viewWidthPixels;
     uint32_t viewHeightPixels;
+    // v13 (DisplayXR runtime v1.4.0+): isActive marks the current mode for
+    // this session; isRequestable is false for non-controller workspace
+    // clients (runtime drops xrRequestDisplayRenderingModeEXT). Plugin
+    // doesn't currently consume them, but the struct sizeof must match
+    // the runtime's so xrEnumerateDisplayRenderingModesEXT writes modes[i]
+    // at the right stride. See DisplayXR/displayxr-runtime#234.
+    XrBool32 isActive;
+    XrBool32 isRequestable;
 } XrDisplayRenderingModeInfoEXT;
 
 typedef XrResult(XRAPI_PTR *PFN_xrEnumerateDisplayRenderingModesEXT)(


### PR DESCRIPTION
## Summary

Closes #11.

Append `isActive` + `isRequestable` (both `XrBool32`) to `XrDisplayRenderingModeInfoEXT` in `Source/DisplayXRCore/Private/Native/displayxr_extensions.h` to match the runtime's v13 layout (DisplayXR/displayxr-runtime#234).

Without this sync, the plugin's `modes[i+1]` reads from `xrEnumerateDisplayRenderingModesEXT` are misaligned against where the runtime wrote them.

Plugin doesn't yet consume the new fields — minimal ABI-only fix.

## Test plan

- [ ] CI build green.
- [ ] Sample project against runtime v13 enumerates modes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)