### PR TITLE
ci: bump actions to Node 24 runtimes ahead of the June 16 default flip

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Vendor-name guard
         run: |
@@ -46,7 +46,7 @@ jobs:
     # longer matches the pinned runtime, so drift is a red check, not a mystery.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Vendored OpenXR extension headers match the pinned runtime
         run: |

--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -19,7 +19,7 @@ jobs:
   no-vendored-math:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: No re-vendored displayxr::math sources
         shell: bash
         run: |


### PR DESCRIPTION
GitHub flips JavaScript actions to a Node 24 default on **June 16**. Bump every action pin to the lowest major that declares `runs.using: node24` (each verified against the tag's `action.yml`). Org-wide sweep; runtime already landed as displayxr-runtime#554.

Mapping: checkout v4→v5, cache v4→v5, upload-artifact v4→v6, download-artifact v4→v7 (v5's breaking path change only affects `artifact-ids:` downloads; ours are by `name:`), setup-java v4→v5, setup-node v4→v5, create-github-app-token v1→v3 (same inputs), repository-dispatch v3→v4, action-gh-release v2→v3, gha-setup-ninja v4→v6 (newest available; Node 20 — no Node 24 release upstream yet).

Left as-is (no Node 24 release exists; will be force-run on Node 24 and expected to work): `ilammy/msvc-dev-cmd@v1`. Already Node 24: `lukka/run-vcpkg@v11`, `nttld/setup-ndk@v1`; `humbletim/install-vulkan-sdk@v1.2` is composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
