### PR TITLE
fix(session): warm session to FOCUSED so apps render under the #33 contract

### DIFF
--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -61,6 +61,16 @@ void FDisplayXRCompositor::CompositorLoop()
 	{
 		if (!Session->IsSessionRunning()) { FPlatformProcess::Sleep(0.01f); continue; }
 
+		// Pump lifecycle events (STOPPING, focus/visibility) on THIS thread,
+		// serialized with the frame calls below — polling on the game thread while
+		// we're mid-frame deadlocks the in-process native compositor. FOCUSED was
+		// already reached in the session's warmup (CreateSessionWithGraphics), so
+		// this only ever sees steady-state and cannot trigger the late-FOCUSED
+		// handshake livelock. On STOPPING it parks the loop; re-check before
+		// beginning a frame so we never xrBeginFrame on an ended session.
+		Session->PumpEvents();
+		if (!Session->IsSessionRunning()) { continue; }
+
 		FrameCount++;
 
 		// xrWaitFrame

--- a/Source/DisplayXRCore/Private/DisplayXRSession.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.cpp
@@ -158,7 +158,7 @@ void FDisplayXRSession::Shutdown()
 
 	UnloadOpenXRLoader();
 	bActive = false;
-	bSessionRunning = false;
+	bSessionRunning.Store(false);
 	UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Shut down"));
 }
 
@@ -702,72 +702,15 @@ void FDisplayXRSession::Tick()
 		return;
 	}
 
-	// Skip xrPollEvent entirely once the session is running and the compositor
-	// thread is active. The runtime's xrPollEvent blocks on the game thread
-	// because the in-process compositor expects all interaction via xrWaitFrame.
-	static int32 SkipPollCount = 0;
-	if (SkipPollCount > 0)
-	{
-		SkipPollCount--;
-	}
-	else if (!bSessionRunning)
-	{
-		// Only poll events during session setup (before RUNNING state).
-		// Once running, the compositor thread handles the runtime.
-		PFN_xrPollEvent xrPollEventFunc = nullptr;
-		xrGetInstanceProcAddrFunc(Instance, "xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
-		if (xrPollEventFunc)
-		{
-			XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
-			while (XR_SUCCEEDED(xrPollEventFunc(Instance, &EventData)))
-			{
-				if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
-				{
-					auto* StateChanged = (XrEventDataSessionStateChanged*)&EventData;
-					SessionState = StateChanged->state;
-
-					if (SessionState == XR_SESSION_STATE_READY)
-					{
-						PFN_xrBeginSession xrBeginSessionFunc = nullptr;
-						xrGetInstanceProcAddrFunc(Instance, "xrBeginSession",
-							(PFN_xrVoidFunction*)&xrBeginSessionFunc);
-						if (xrBeginSessionFunc)
-						{
-							XrSessionBeginInfo BeginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
-							BeginInfo.primaryViewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
-							UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Calling xrBeginSession..."));
-							GLog->Flush();
-							XrResult BeginResult = xrBeginSessionFunc(Session, &BeginInfo);
-							UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: xrBeginSession returned %d"), (int)BeginResult);
-							GLog->Flush();
-							bSessionRunning = true;
-							UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Session running"));
-							GLog->Flush();
-							// Skip xrPollEvent for several ticks to let the compositor
-							// thread start its frame loop before we poll again.
-							SkipPollCount = 60;
-							break; // Exit the while loop
-						}
-					}
-					else if (SessionState == XR_SESSION_STATE_STOPPING)
-					{
-						PFN_xrEndSession xrEndSessionFunc = nullptr;
-						xrGetInstanceProcAddrFunc(Instance, "xrEndSession",
-							(PFN_xrVoidFunction*)&xrEndSessionFunc);
-						if (xrEndSessionFunc)
-						{
-							xrEndSessionFunc(Session);
-						}
-						bSessionRunning = false;
-					}
-				}
-				EventData = {XR_TYPE_EVENT_DATA_BUFFER};
-			}
-		}
-	}
+	// NOTE: the game thread does NOT poll xrPollEvent. The session is begun and
+	// driven to FOCUSED synchronously in CreateSessionWithGraphics (warmup loop,
+	// before the compositor thread starts), and ongoing lifecycle events are
+	// pumped on the compositor thread via PumpEvents() — serialized with the
+	// frame calls. Polling here (game thread) while the compositor thread is
+	// mid-frame deadlocks the in-process native compositor.
 
 	// Locate views for eye tracking data
-	if (bSessionRunning && Session != XR_NULL_HANDLE && ViewSpace != XR_NULL_HANDLE)
+	if (bSessionRunning.Load() && Session != XR_NULL_HANDLE && ViewSpace != XR_NULL_HANDLE)
 	{
 		static bool bFirstLocate = true;
 		if (bFirstLocate)
@@ -993,16 +936,18 @@ bool FDisplayXRSession::CreateSessionWithGraphics(void* D3DDevice, void* Command
 		// Destroy existing bare session to replace with graphics-bound session
 		UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Destroying existing session to create one with graphics binding"));
 
-		if (bSessionRunning)
+		if (bSessionRunning.Load())
 		{
-			PFN_xrEndSession xrEndSessionFunc = nullptr;
-			xrGetInstanceProcAddrFunc(Instance, "xrEndSession",
-				(PFN_xrVoidFunction*)&xrEndSessionFunc);
+			if (!xrEndSessionFunc)
+			{
+				xrGetInstanceProcAddrFunc(Instance, "xrEndSession",
+					(PFN_xrVoidFunction*)&xrEndSessionFunc);
+			}
 			if (xrEndSessionFunc)
 			{
 				xrEndSessionFunc(Session);
 			}
-			bSessionRunning = false;
+			bSessionRunning.Store(false);
 		}
 
 		if (ViewSpace != XR_NULL_HANDLE)
@@ -1025,7 +970,7 @@ bool FDisplayXRSession::CreateSessionWithGraphics(void* D3DDevice, void* Command
 			xrDestroySessionFunc(Session);
 		}
 		Session = XR_NULL_HANDLE;
-		SessionState = XR_SESSION_STATE_UNKNOWN;
+		SessionState.Store(XR_SESSION_STATE_UNKNOWN);
 	}
 
 	if (Instance == XR_NULL_HANDLE || !xrGetInstanceProcAddrFunc)
@@ -1131,59 +1076,181 @@ bool FDisplayXRSession::CreateSessionWithGraphics(void* D3DDevice, void* Command
 
 	UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Session created with graphics binding"));
 
-	// Begin the session synchronously. The runtime posts XR_SESSION_STATE_READY
-	// at xrCreateSession, so polling here (mirroring the editor preview's
-	// Start()) gets the session running — and the display into 3D mode — in
-	// the same call, instead of waiting on per-frame Tick() event polling.
+	// Begin the session and warm it to FOCUSED synchronously, on the game thread,
+	// BEFORE the compositor thread starts its free-running frame loop.
+	//
+	// Per the runtime's CTS-compliant session-state contract (#33): a graphics
+	// session stays at READY through xrBeginSession; the FIRST xrBeginFrame fires
+	// READY->SYNCHRONIZED, and a subsequent xrPollEvent then walks
+	// SYNCHRONIZED->VISIBLE->FOCUSED (the native compositor reports
+	// visible/focused = true). So reaching FOCUSED needs a running frame loop AND
+	// polling. We pump a few empty frames + polls here so the session is already
+	// FOCUSED (xrWaitFrame -> shouldRender=true) by the time the compositor thread
+	// takes over — restoring the clean frame-1 handshake. Reaching FOCUSED *late*,
+	// after the compositor loop has started submitting empty frames, livelocks the
+	// 3-thread image handshake, so it must happen up front, here.
 	{
-		PFN_xrPollEvent xrPollEventFunc = nullptr;
-		xrGetInstanceProcAddrFunc(Instance, "xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
+		if (!xrPollEventFunc)
+		{
+			xrGetInstanceProcAddrFunc(Instance, "xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
+		}
 		PFN_xrBeginSession xrBeginSessionFunc = nullptr;
 		xrGetInstanceProcAddrFunc(Instance, "xrBeginSession", (PFN_xrVoidFunction*)&xrBeginSessionFunc);
+		PFN_xrWaitFrame xrWaitFrameFunc = nullptr;
+		xrGetInstanceProcAddrFunc(Instance, "xrWaitFrame", (PFN_xrVoidFunction*)&xrWaitFrameFunc);
+		PFN_xrBeginFrame xrBeginFrameFunc = nullptr;
+		xrGetInstanceProcAddrFunc(Instance, "xrBeginFrame", (PFN_xrVoidFunction*)&xrBeginFrameFunc);
+		PFN_xrEndFrame xrEndFrameFunc = nullptr;
+		xrGetInstanceProcAddrFunc(Instance, "xrEndFrame", (PFN_xrVoidFunction*)&xrEndFrameFunc);
 
+		// 1. Drain events until READY, then xrBeginSession.
+		bool bBegan = false;
 		if (xrPollEventFunc && xrBeginSessionFunc)
 		{
-			for (int i = 0; i < 100; i++)
+			for (int i = 0; i < 100 && !bBegan; i++)
 			{
 				XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
 				if (!XR_SUCCEEDED(xrPollEventFunc(Instance, &EventData)))
 				{
 					break;
 				}
-
 				if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
 				{
-					auto* StateChanged = (XrEventDataSessionStateChanged*)&EventData;
-					SessionState = StateChanged->state;
-
-					if (SessionState == XR_SESSION_STATE_READY)
+					auto* SC = (XrEventDataSessionStateChanged*)&EventData;
+					SessionState.Store(SC->state);
+					if (SC->state == XR_SESSION_STATE_READY)
 					{
 						XrSessionBeginInfo BeginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
 						BeginInfo.primaryViewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 						XrResult BeginResult = xrBeginSessionFunc(Session, &BeginInfo);
 						if (XR_SUCCEEDED(BeginResult))
 						{
-							bSessionRunning = true;
-							UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Session running (begun synchronously at create)"));
+							bBegan = true;
 						}
 						else
 						{
 							UE_LOG(LogDisplayXRSession, Warning, TEXT("DisplayXR Session: xrBeginSession failed (%d)"), (int)BeginResult);
 						}
-						break;
 					}
 				}
 			}
 		}
 
-		if (!bSessionRunning)
+		// 2. Warm to FOCUSED by pumping empty frames + draining events. Bounded so
+		//    a runtime that never focuses cannot hang session setup.
+		if (bBegan && xrWaitFrameFunc && xrBeginFrameFunc && xrEndFrameFunc && xrPollEventFunc)
 		{
-			// Non-fatal: Tick()'s per-frame event polling remains as fallback.
-			UE_LOG(LogDisplayXRSession, Warning, TEXT("DisplayXR Session: READY not posted synchronously; falling back to per-frame event polling"));
+			for (int i = 0; i < 60; i++)
+			{
+				// VISIBLE is enough: shouldRender is true once visible, so content
+				// renders even if the workspace hasn't granted input focus yet; the
+				// compositor-thread pump advances VISIBLE->FOCUSED afterwards.
+				const XrSessionState s = SessionState.Load();
+				if (s == XR_SESSION_STATE_VISIBLE || s == XR_SESSION_STATE_FOCUSED) break;
+
+				XrFrameWaitInfo WI = {XR_TYPE_FRAME_WAIT_INFO};
+				XrFrameState FS = {XR_TYPE_FRAME_STATE};
+				if (!XR_SUCCEEDED(xrWaitFrameFunc(Session, &WI, &FS)))
+				{
+					continue;
+				}
+				XrFrameBeginInfo BI = {XR_TYPE_FRAME_BEGIN_INFO};
+				if (!XR_SUCCEEDED(xrBeginFrameFunc(Session, &BI)))
+				{
+					continue;
+				}
+				// Empty (0-layer) frame — legal; no swapchain exists yet. The first
+				// xrBeginFrame above fired READY->SYNCHRONIZED; the poll below then
+				// advances toward FOCUSED.
+				XrFrameEndInfo EI = {XR_TYPE_FRAME_END_INFO};
+				EI.displayTime = FS.predictedDisplayTime;
+				EI.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+				xrEndFrameFunc(Session, &EI);
+
+				XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+				// NB: drain on == XR_SUCCESS, NOT XR_SUCCEEDED — xrPollEvent returns
+				// XR_EVENT_UNAVAILABLE (a POSITIVE/"succeeded" code) when the queue is
+				// empty, so XR_SUCCEEDED would spin forever.
+				while (xrPollEventFunc(Instance, &EventData) == XR_SUCCESS)
+				{
+					if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
+					{
+						SessionState.Store(((XrEventDataSessionStateChanged*)&EventData)->state);
+					}
+					EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+				}
+			}
+		}
+
+		if (bBegan)
+		{
+			bSessionRunning.Store(true);
+			UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: Session running (warmed to state %d)"), (int)SessionState.Load());
+			const XrSessionState Warmed = SessionState.Load();
+			if (Warmed != XR_SESSION_STATE_VISIBLE && Warmed != XR_SESSION_STATE_FOCUSED)
+			{
+				// Non-fatal: the compositor-thread PumpEvents() keeps advancing the
+				// state; the first few frames may be empty until VISIBLE is reached.
+				UE_LOG(LogDisplayXRSession, Warning, TEXT("DisplayXR Session: warmup did not reach VISIBLE (state %d); relying on compositor-thread poll"), (int)Warmed);
+			}
+		}
+		else
+		{
+			UE_LOG(LogDisplayXRSession, Warning, TEXT("DisplayXR Session: READY not posted; session not begun"));
 		}
 	}
 
 	return true;
+}
+
+// =============================================================================
+// Compositor-thread event pump (lifecycle: STOPPING, focus/visibility changes)
+// =============================================================================
+void FDisplayXRSession::PumpEvents()
+{
+	if (Instance == XR_NULL_HANDLE || Session == XR_NULL_HANDLE || !xrGetInstanceProcAddrFunc)
+	{
+		return;
+	}
+	if (!xrPollEventFunc)
+	{
+		xrGetInstanceProcAddrFunc(Instance, "xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
+		if (!xrPollEventFunc)
+		{
+			return;
+		}
+	}
+
+	// NB: drain on == XR_SUCCESS, NOT XR_SUCCEEDED — xrPollEvent returns
+	// XR_EVENT_UNAVAILABLE (a POSITIVE/"succeeded" code) when the queue is empty,
+	// so XR_SUCCEEDED would spin this thread forever.
+	XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+	while (xrPollEventFunc(Instance, &EventData) == XR_SUCCESS)
+	{
+		if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
+		{
+			auto* SC = (XrEventDataSessionStateChanged*)&EventData;
+			SessionState.Store(SC->state);
+
+			if (SC->state == XR_SESSION_STATE_STOPPING)
+			{
+				// End the session and park the compositor loop. Final teardown
+				// (xrDestroySession) happens in Shutdown() on the game thread,
+				// serialized after StopCompositorThread() joins this thread.
+				if (!xrEndSessionFunc)
+				{
+					xrGetInstanceProcAddrFunc(Instance, "xrEndSession", (PFN_xrVoidFunction*)&xrEndSessionFunc);
+				}
+				if (xrEndSessionFunc)
+				{
+					xrEndSessionFunc(Session);
+				}
+				bSessionRunning.Store(false);
+				UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: STOPPING — session ended, frame loop parked"));
+			}
+		}
+		EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+	}
 }
 
 void FDisplayXRSession::SetSceneTransform(const FTransform& InTransform, bool bEnabled)

--- a/Source/DisplayXRCore/Private/DisplayXRSession.h
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.h
@@ -64,8 +64,17 @@ public:
 	/** Shutdown: destroy session + instance, unload loader. */
 	void Shutdown();
 
-	/** Per-frame tick: poll events, locate views, store eye positions. */
+	/** Per-frame tick: locate views, store eye positions (game thread). */
 	void Tick();
+
+	/**
+	 * Drain xrPollEvent and advance the cached session state. MUST be called on
+	 * the compositor thread (serialized with xrWaitFrame/Begin/End) — polling on
+	 * the game thread while the compositor thread is mid-frame deadlocks the
+	 * in-process native compositor. Handles XR_SESSION_STATE_STOPPING by ending
+	 * the session and parking the frame loop. No-op until the session exists.
+	 */
+	void PumpEvents();
 
 	/** Check if the session is active (instance created, display info available). */
 	bool IsActive() const { return bActive; }
@@ -113,7 +122,7 @@ public:
 	XrInstance GetXrInstance() const { return Instance; }
 	XrSpace GetXrSpace() const { return ViewSpace; }
 	PFN_xrGetInstanceProcAddr GetXrGetInstanceProcAddr() const { return xrGetInstanceProcAddrFunc; }
-	bool IsSessionRunning() const { return bSessionRunning; }
+	bool IsSessionRunning() const { return bSessionRunning.Load(); }
 
 	/** Store predicted display time from compositor thread for xrLocateViews. */
 	void SetPredictedDisplayTime(int64 Time) { PredictedDisplayTime.Store(Time); }
@@ -150,14 +159,20 @@ private:
 	XrSession Session = XR_NULL_HANDLE;
 	XrSystemId SystemId = XR_NULL_SYSTEM_ID;
 	XrSpace ViewSpace = XR_NULL_HANDLE;
-	XrSessionState SessionState = XR_SESSION_STATE_UNKNOWN;
-	bool bSessionRunning = false;
+	// Atomic: written by the warmup loop (game thread, during setup) and the
+	// compositor-thread PumpEvents(); read by both threads (IsSessionRunning,
+	// CompositorLoop park gate, Tick LocateViews gate).
+	TAtomic<XrSessionState> SessionState{XR_SESSION_STATE_UNKNOWN};
+	TAtomic<bool> bSessionRunning{false};
 
 	// Function pointers (resolved via xrGetInstanceProcAddr)
 	PFN_xrGetInstanceProcAddr xrGetInstanceProcAddrFunc = nullptr;
 	PFN_xrRequestDisplayModeEXT xrRequestDisplayModeFunc = nullptr;
 	PFN_xrEnumerateDisplayRenderingModesEXT xrEnumerateDisplayRenderingModesFunc = nullptr;
 	PFN_xrCaptureAtlasEXT xrCaptureAtlasFunc = nullptr;
+	// Cached for the compositor-thread event pump (resolved lazily in PumpEvents).
+	PFN_xrPollEvent xrPollEventFunc = nullptr;
+	PFN_xrEndSession xrEndSessionFunc = nullptr;
 
 	// Display info (written once at init)
 	FDisplayXRDisplayInfo DisplayInfo;

--- a/Source/DisplayXREditor/Private/DisplayXRPreviewSession.cpp
+++ b/Source/DisplayXREditor/Private/DisplayXRPreviewSession.cpp
@@ -357,24 +357,28 @@ bool FDisplayXRPreviewSession::Start()
 		return false;
 	}
 
-	// 7. Poll events until READY, then xrBeginSession
+	// 7. Drain events until READY -> xrBeginSession, then WARM the session to
+	//    FOCUSED by pumping empty frames + polls. Per the runtime's CTS-compliant
+	//    session-state contract (#33): a graphics session stays at READY through
+	//    xrBeginSession; the first xrBeginFrame fires READY->SYNCHRONIZED, and a
+	//    subsequent xrPollEvent walks SYNCHRONIZED->VISIBLE->FOCUSED. Reaching
+	//    FOCUSED here means the first real Tick() frame renders instead of black.
 	{
-		PFN_xrPollEvent xrPollEventFunc = nullptr;
-		xrGetInstanceProcAddrFunc(Instance, "xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
 		PFN_xrBeginSession xrBeginSessionFunc = nullptr;
 		xrGetInstanceProcAddrFunc(Instance, "xrBeginSession", (PFN_xrVoidFunction*)&xrBeginSessionFunc);
 
+		bool bBegan = false;
 		if (xrPollEventFunc && xrBeginSessionFunc)
 		{
-			for (int i = 0; i < 100; i++)
+			for (int i = 0; i < 100 && !bBegan; i++)
 			{
 				XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
-				XrResult r = xrPollEventFunc(Instance, &EventData);
-				if (!XR_SUCCEEDED(r)) break;
+				if (!XR_SUCCEEDED(xrPollEventFunc(Instance, &EventData))) break;
 
 				if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
 				{
 					auto* SC = (XrEventDataSessionStateChanged*)&EventData;
+					SessionState = SC->state;
 					if (SC->state == XR_SESSION_STATE_READY)
 					{
 						XrSessionBeginInfo BeginInfo = {XR_TYPE_SESSION_BEGIN_INFO};
@@ -382,20 +386,56 @@ bool FDisplayXRPreviewSession::Start()
 						XrResult BeginResult = xrBeginSessionFunc(Session, &BeginInfo);
 						if (XR_SUCCEEDED(BeginResult))
 						{
-							bSessionRunning = true;
-							UE_LOG(LogDisplayXRPreviewSession, Log, TEXT("DisplayXR Preview: Session running"));
+							bBegan = true;
 						}
 						else
 						{
 							UE_LOG(LogDisplayXRPreviewSession, Error, TEXT("DisplayXR Preview: xrBeginSession failed (%d)"), (int)BeginResult);
 						}
-						break;
 					}
 				}
 			}
 		}
 
-		if (!bSessionRunning)
+		// Warm to FOCUSED with empty (0-layer) frames — no swapchain yet (created
+		// at step 9). Bounded so a non-focusing runtime can't hang PIE start.
+		if (bBegan && xrWaitFrameFunc && xrBeginFrameFunc && xrEndFrameFunc)
+		{
+			for (int i = 0; i < 60; i++)
+			{
+				// VISIBLE is enough — shouldRender is true once visible.
+				if (SessionState == XR_SESSION_STATE_VISIBLE || SessionState == XR_SESSION_STATE_FOCUSED) break;
+
+				XrFrameWaitInfo WI = {XR_TYPE_FRAME_WAIT_INFO};
+				XrFrameState FS = {XR_TYPE_FRAME_STATE};
+				if (!XR_SUCCEEDED(xrWaitFrameFunc(Session, &WI, &FS))) continue;
+				XrFrameBeginInfo BI = {XR_TYPE_FRAME_BEGIN_INFO};
+				if (!XR_SUCCEEDED(xrBeginFrameFunc(Session, &BI))) continue;
+				XrFrameEndInfo EI = {XR_TYPE_FRAME_END_INFO};
+				EI.displayTime = FS.predictedDisplayTime;
+				EI.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+				xrEndFrameFunc(Session, &EI);
+
+				XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+				// NB: drain on == XR_SUCCESS, NOT XR_SUCCEEDED — xrPollEvent returns
+		// XR_EVENT_UNAVAILABLE (a POSITIVE/"succeeded" code) when the queue is empty.
+		while (xrPollEventFunc(Instance, &EventData) == XR_SUCCESS)
+				{
+					if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
+					{
+						SessionState = ((XrEventDataSessionStateChanged*)&EventData)->state;
+					}
+					EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+				}
+			}
+		}
+
+		if (bBegan)
+		{
+			bSessionRunning = true;
+			UE_LOG(LogDisplayXRPreviewSession, Log, TEXT("DisplayXR Preview: Session running (warmed to state %d)"), (int)SessionState);
+		}
+		else
 		{
 			UE_LOG(LogDisplayXRPreviewSession, Error, TEXT("DisplayXR Preview: Session did not reach READY state"));
 			DestroyXrSession();
@@ -516,6 +556,24 @@ void FDisplayXRPreviewSession::Tick()
 
 	// Update canvas rect every tick (catches resize/move even if WndProc is delayed)
 	UpdateCanvasRect();
+
+	// Drain lifecycle events each tick (single-threaded — safe on the game thread,
+	// serialized with the frame calls below). Keeps SessionState current and lets
+	// the runtime state machine advance past any transient SYNCHRONIZED re-entry.
+	if (xrPollEventFunc)
+	{
+		XrEventDataBuffer EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+		// NB: drain on == XR_SUCCESS, NOT XR_SUCCEEDED — xrPollEvent returns
+		// XR_EVENT_UNAVAILABLE (a POSITIVE/"succeeded" code) when the queue is empty.
+		while (xrPollEventFunc(Instance, &EventData) == XR_SUCCESS)
+		{
+			if (EventData.type == XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED)
+			{
+				SessionState = ((XrEventDataSessionStateChanged*)&EventData)->state;
+			}
+			EventData = {XR_TYPE_EVENT_DATA_BUFFER};
+		}
+	}
 
 	// xrWaitFrame (blocks for vsync — acceptable on editor game thread)
 	XrFrameWaitInfo WaitInfo = {XR_TYPE_FRAME_WAIT_INFO};
@@ -1378,6 +1436,7 @@ bool FDisplayXRPreviewSession::ResolveXrFunctions()
 	ok &= R("xrWaitSwapchainImage", (PFN_xrVoidFunction*)&xrWaitSwapchainImageFunc);
 	ok &= R("xrReleaseSwapchainImage", (PFN_xrVoidFunction*)&xrReleaseSwapchainImageFunc);
 	ok &= R("xrLocateViews", (PFN_xrVoidFunction*)&xrLocateViewsFunc);
+	ok &= R("xrPollEvent", (PFN_xrVoidFunction*)&xrPollEventFunc);
 	return ok;
 }
 

--- a/Source/DisplayXREditor/Private/DisplayXRPreviewSession.h
+++ b/Source/DisplayXREditor/Private/DisplayXRPreviewSession.h
@@ -180,4 +180,8 @@ private:
 	PFN_xrWaitSwapchainImage xrWaitSwapchainImageFunc = nullptr;
 	PFN_xrReleaseSwapchainImage xrReleaseSwapchainImageFunc = nullptr;
 	PFN_xrLocateViews xrLocateViewsFunc = nullptr;
+	PFN_xrPollEvent xrPollEventFunc = nullptr;
+
+	// Current session state, tracked from xrPollEvent (single-threaded: game thread).
+	XrSessionState SessionState = XR_SESSION_STATE_UNKNOWN;
 };


### PR DESCRIPTION
## Problem
Since runtime commit `a6420d910` (#33) made graphics sessions CTS-compliant, a DisplayXR Unreal app rendered **black** in every mode. The runtime no longer drives a graphics session to FOCUSED at `xrBeginSession`: `READY→SYNCHRONIZED` fires on the first `xrBeginFrame`, and `SYNCHRONIZED→VISIBLE→FOCUSED` advances **only** via `xrPollEvent`. The v0.4.2 plugin began the session synchronously then stopped polling → stuck at SYNCHRONIZED → `xrWaitFrame` `shouldRender=false` → the compositor submitted empty 0-layer frames forever → black.

## Fix (plugin-only — no runtime change)
- **`CreateSessionWithGraphics` warms the session to VISIBLE/FOCUSED** on the game thread (poll→READY→`xrBeginSession`, then a bounded loop of empty frame + poll-drain) **before** the compositor thread starts, so its first real frame already has `shouldRender=true` — restoring the clean pre-#33 frame-1 handshake. (VISIBLE is enough: `shouldRender` is true once visible.)
- **New `PumpEvents()` on the compositor thread** drains lifecycle events (STOPPING → end + park), serialized with the frame calls — polling on the game thread mid-frame deadlocks the in-process native compositor.
- Removed the dead game-thread poll from `Tick()`; `SessionState`/`bSessionRunning` are now `TAtomic`.
- **Editor preview** gets the same warmup + a per-tick poll drain.

### The actual "Layer-2 hang"
Earlier attempts hit a hang that looked like a frame-sync livelock. Root cause was a drain loop using `while (XR_SUCCEEDED(xrPollEvent(...)))`: `xrPollEvent` returns `XR_EVENT_UNAVAILABLE` (=4, a *positive*/"succeeded" code) when the queue is empty, so the loop spun forever. Drain loops now use `== XR_SUCCESS`.

## Verification
- **In-process (Leia):** session reaches FOCUSED, real 2-view atlas renders (the SimpleCube crate in stereo), `Responding=True`, no hang. ✅
- **IPC/shell:** session reaches FOCUSED and submits frames, but content arrives **black at the service compositor** — a **separate, UE-specific** IPC swapchain bug (the native `cube_handle_d3d12_win` app renders fine over the same forced-IPC path; not shell window-hiding). Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)