### PR TITLE
feat(signing): SIGN_CMD-gated signing of packaged plugin binaries (#666)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -160,6 +160,33 @@ This prints because `GetUnrealInstallPath.bat` probes the registry first and fal
 ### Step 3.2: Strip binaries we don't want to ship (optional)
 Remove `Packages\DisplayXR_5.7\Intermediate\` if UAT left it behind — the shipped ZIP should only contain source + `Binaries/Win64/*`, `Resources/`, `Config/`, `DisplayXR.uplugin`.
 
+### Step 3.2.5: Code-sign the packaged binaries (capability-gated)
+The packaged plugin ships **precompiled** `Binaries\Win64\*.dll` (the
+DisplayXR UE module DLLs for engine 5.7) — these load into the user's
+UE editor, so Smart App Control blocks them unsigned. Sign them here,
+**before** zipping. (Unreal is the simplest of the three plugin repos —
+everything is already local, no CI asset to replace.)
+
+Gated on `SIGN_CMD`, set only on a signing-capable build machine.
+Without it, the build is unsigned exactly as before — no failure.
+
+```bash
+if [ -n "$SIGN_CMD" ] && uname -s | grep -qiE 'mingw|msys|cygwin|windows'; then
+  echo "=== Signing packaged Unreal binaries ==="
+  powershell -NoProfile -ExecutionPolicy Bypass -File Scripts\\sign-release.ps1 \
+    -Path "Packages\\DisplayXR_5.7\\Binaries\\Win64" -SignCmd "$SIGN_CMD"
+  # exit non-zero from the script fails the release — do not zip unsigned
+  SIGNED=yes
+else
+  echo "⚠  SIGNING SKIPPED — no signing capability; ZIP will be UNSIGNED."
+  SIGNED=no
+fi
+```
+Carry `SIGNED` into the final report. Note: when a UE developer recompiles
+the plugin for a different engine version or for their packaged game, UE
+regenerates those DLLs — those rebuilt binaries are the developer's to
+sign (their distribution), the same as any UE plugin.
+
 ### Step 3.3: Zip the packaged plugin
 Use pwsh:
 ```powershell

--- a/Scripts/sign-release.ps1
+++ b/Scripts/sign-release.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Sign all DisplayXR-produced binaries in a release folder, then verify the
+  whole tree is signed.
+
+.DESCRIPTION
+  Signing is driven entirely by the command passed in -SignCmd (sourced from
+  the SIGN_CMD environment variable by the build scripts). This script holds
+  NO certificate and NO secret. On machines without signing capability,
+  SIGN_CMD is unset and the build scripts skip signing — the build is
+  unsigned, with no behavior change.
+
+    1. Walk the folder for *.dll / *.exe.
+    2. Any binary WITHOUT a Valid Authenticode signature -> sign it via the
+       configured signer. Binaries that already carry a valid signature
+       (e.g. bundled third-party DLLs) are left untouched.
+    3. Re-verify the ENTIRE tree. If anything is still unsigned, FAIL (exit 1).
+
+  -SignCmd receives the file path as a trailing argument. Callers pass a full
+  signing command (including their own timestamp authority) via SIGN_CMD; the
+  default below is a minimal fallback for ad-hoc use.
+
+.EXAMPLE
+  # sign a staged binary tree before packaging
+  .\sign-release.ps1 -Path .\_package\bin -SignCmd "$env:SIGN_CMD"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    # Signing command; receives the file path as a trailing argument.
+    # Production callers pass a full command (with a timestamp authority)
+    # via the SIGN_CMD environment variable. This default is a bare fallback.
+    [string]$SignCmd = 'signtool sign /fd sha256 /a',
+
+    # Skip signing files already validly signed by anyone (default). Use
+    # -Force to re-sign every binary regardless (overwrites existing sigs).
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Signed($file) {
+    (Get-AuthenticodeSignature $file).Status -eq 'Valid'
+}
+
+function Invoke-Sign($file) {
+    $parts = $SignCmd -split '\s+'
+    $exe   = $parts[0]
+    $args  = @($parts[1..($parts.Length - 1)]) + $file
+    & $exe @args
+    if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file (exit $LASTEXITCODE)" }
+}
+
+if (-not (Test-Path $Path)) { throw "Path not found: $Path" }
+
+$binaries = Get-ChildItem -Path $Path -Recurse -Include *.dll, *.exe -File
+Write-Host "Found $($binaries.Count) binaries under $Path"
+
+$signed = 0; $skipped = 0
+foreach ($b in $binaries) {
+    if (-not $Force -and (Test-Signed $b.FullName)) {
+        $who = (Get-AuthenticodeSignature $b.FullName).SignerCertificate.Subject
+        Write-Host "  skip (already signed) : $($b.Name)  <$who>"
+        $skipped++
+        continue
+    }
+    Write-Host "  signing               : $($b.Name)"
+    Invoke-Sign $b.FullName
+    $signed++
+}
+
+Write-Host "Signed $signed, skipped $skipped already-signed."
+
+# ---- Verification gate ----
+$unsigned = $binaries | Where-Object { -not (Test-Signed $_.FullName) }
+if ($unsigned) {
+    Write-Host "`nFAIL: the following binaries are still unsigned:" -ForegroundColor Red
+    $unsigned | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`nOK: all $($binaries.Count) binaries under $Path are signed." -ForegroundColor Green


### PR DESCRIPTION
Adds capability-gated (`SIGN_CMD`) code-signing of the packaged plugin binaries so a released package is Authenticode-signed and won't be blocked by the OS application-control policy that rejects unsigned native DLLs.

Part of the bundle-wide signing rollout tracked in #666. This component has no NSIS installer, so signing happens in the release/package step (shape B): the precompiled module DLLs in the packaged output are signed in place before the ZIP is created. This is the simplest of the engine-plugin repos — everything is already local, there is no CI asset to download and replace.

## What changed
- **`Scripts/sign-release.ps1`** — signs any `*.dll`/`*.exe` lacking a Valid Authenticode signature via the command in `SIGN_CMD`, then fails if anything is left unsigned. Carries no certificate and no secret (same script used across the other bundle components).
- **`.claude/skills/release/SKILL.md`** — new step that, only when `SIGN_CMD` is set and the host is a signing-capable Windows machine, signs the packaged `Binaries\Win64\*.dll` before zipping. Without signing capability it logs a skip and produces an unsigned ZIP, exactly as before.

A developer who recompiles the plugin for a different engine version or for their own packaged title regenerates those DLLs — signing those rebuilt binaries is the developer's responsibility for their own distribution, as with any engine plugin.

## Why no secret lives here
Signing is driven entirely by the `SIGN_CMD` env var, set only on a signing-capable build machine. Cloud CI and clones leave it unset and produce an unsigned package with no behavior change.

## Validation
With a throwaway self-signed cert, running `sign-release.ps1` against the three packaged module DLLs took each from NotSigned to Authenticode-**Valid** and they pass `signtool verify /pa`. The same `sign-release.ps1` is already validated across the runtime + the other bundle components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)