### PR TITLE
feat(shell): UE renders over IPC as a first-class shell citizen + Ctrl passthrough (#667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the DisplayXR Unreal plugin are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-06-29
+
+UE is now a first-class DisplayXR shell citizen — it renders correctly over IPC and behaves correctly under the workspace shell.
+
+### Added
+- **Render over IPC (shell / forced-IPC).** The single-tiled `arraySize=1` shared-texture swapchain is non-coherent cross-process from UE's process (proven: even a dedicated device's writes don't reach the D3D11 service). Over IPC, UE now renders both eyes side-by-side into a private RT and `CopyTexture`s each eye into a slice of a canonical `arraySize=2` RGBA swapchain (robust on an engine device). In-process keeps the single-tiled zero-copy path. Resolves the 0.4.3 "content arrives black at the service compositor" known issue. (#23)
+- **Camera-look under the shell.** UE routes mouse by capture/cursor-position, not focus, so under the shell (cursor over the shell window, UE never foreground) injected input is dropped. The plugin now feeds the forwarded drag delta straight to the local `PlayerController` (`AddYaw/PitchInput`, the same path the game's own look mapping uses), driving look regardless of focus/capture.
+- **Keyboard input under the shell.** Forwarded `WM_KEY*`/`WM_MOUSE*` are relayed from the bound overlay to UE's real window (WASD/QE). Ctrl is intentionally swallowed — the shell reserves it for its chords (Ctrl+L / Ctrl+1/2/3 / Ctrl+Space) and UE's default pawn binds LeftControl to vertical movement.
+
+### Fixed
+- **Teardown hang.** Closing the app under the shell hung forever — the runtime drives `EXIT_REQUEST → STOPPING`; `xrEndSession` then queues `EXITING`, but the compositor loop parked on STOPPING before polling again, so EXITING was never received and the app spun a parked session-less loop. The loop now pumps events every iteration (before the park gate), requests engine exit on `EXITING`, and wakes/bails the game thread on park. Closes instantly.
+- **Stray fullscreen window over the shell.** UE's own top-level window showed its mono mirror on the desktop. It is now clipped to an empty region (full-size at its origin so the overlay geometry + Kooima and the swapchain present are untouched), and — because UE's blocking startup load stalls the game thread — a small watcher thread (independent of the game thread) hides it the instant it appears, so it no longer covers the shell during load.
+- **App didn't show until alt-tab.** UE renders the whole time but grabs OS foreground on launch, so the shell stopped displaying it. The shell's foreground window is captured at module load and handed back after the window is hidden; the app now appears on launch without an alt-tab. Also keeps UE rendering while unfocused (`t.IdleWhenNotForeground=0`, set at module load).
+
 ## [0.4.3] - 2026-06-27
 
 ### Fixed

--- a/DisplayXR.uplugin
+++ b/DisplayXR.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "0.4.3",
+	"VersionName": "0.5.0",
 	"EngineVersion": "5.7.0",
 	"FriendlyName": "DisplayXR",
 	"Description": "3D display rendering for tracked displays",

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -3,6 +3,7 @@
 
 #include "DisplayXRCompositor.h"
 #include "DisplayXRPlatform.h"
+#include "HAL/IConsoleManager.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
@@ -113,17 +114,32 @@ void FDisplayXRCompositor::CompositorLoop()
 
 	while (!bStopRequested.Load())
 	{
-		if (!Session->IsSessionRunning()) { FPlatformProcess::Sleep(0.01f); continue; }
-
-		// Pump lifecycle events (STOPPING, focus/visibility) on THIS thread,
-		// serialized with the frame calls below — polling on the game thread while
-		// we're mid-frame deadlocks the in-process native compositor. FOCUSED was
-		// already reached in the session's warmup (CreateSessionWithGraphics), so
-		// this only ever sees steady-state and cannot trigger the late-FOCUSED
-		// handshake livelock. On STOPPING it parks the loop; re-check before
-		// beginning a frame so we never xrBeginFrame on an ended session.
+		// Pump lifecycle events (STOPPING, EXITING, focus/visibility) on THIS
+		// (compositor) thread, serialized with the frame calls below. FOCUSED was
+		// already reached in the session warmup (CreateSessionWithGraphics), so this
+		// only ever sees steady-state and cannot trigger the late-FOCUSED handshake
+		// livelock. CRITICAL: this MUST run even when the session is parked. On a
+		// shell close the runtime drives EXIT_REQUEST → STOPPING; we call
+		// xrEndSession (parking the session), which makes the runtime queue
+		// EXITING — but EXITING is only delivered on a SUBSEQUENT poll. The old code
+		// gated PumpEvents behind IsSessionRunning and parked first, so after
+		// STOPPING it never polled again: EXITING was stranded, nothing requested
+		// app exit, and the process spun a parked, session-less loop forever (the
+		// teardown "hang"). Pump first, unconditionally.
 		Session->PumpEvents();
-		if (!Session->IsSessionRunning()) { continue; }
+
+		// Parked (session ended, e.g. post-STOPPING / awaiting EXITING). Wake any
+		// game thread blocked in AcquireImage_GameThread (manual-reset
+		// BeginFrameReadyEvent) so it bails with -1 instead of crawling at its
+		// 500ms timeout while UE shuts down. Keep looping so PumpEvents above can
+		// still receive EXITING and request exit. The loop exits when UE's HMD
+		// shutdown calls StopCompositorThread (bStopRequested).
+		if (!Session->IsSessionRunning())
+		{
+			if (BeginFrameReadyEvent) BeginFrameReadyEvent->Trigger();
+			FPlatformProcess::Sleep(0.01f);
+			continue;
+		}
 
 		FrameCount++;
 
@@ -216,6 +232,25 @@ void FDisplayXRCompositor::CompositorLoop()
 						SWP_NOZORDER | SWP_NOACTIVATE);
 				}
 			}
+		}
+		// Under the shell, UE's own top-level window would otherwise show its
+		// fullscreen mono mirror on the desktop, over the shell. Hide it WITHOUT
+		// changing its style, size, or position — every other approach perturbs the
+		// 3D content:
+		//   - off-screen park / shrink drags or clips the WS_CHILD overlay the
+		//     runtime measures -> DISTORTED content;
+		//   - WS_EX_LAYERED (transparent) breaks UE's flip-model present to the
+		//     window, UE falls back to a differently-aligned render -> WRONG POV
+		//     (camera too low). (Confirmed: hidden-via-layered <-> POV shifted.)
+		// Instead clip the window to an EMPTY region: the window rect stays
+		// full-size at its origin (overlay geometry + runtime Kooima untouched, the
+		// swapchain present is NOT redirected) but nothing composites to the
+		// desktop. UE keeps rendering its scene (which the plugin copies into the
+		// array swapchain) — paired with t.IdleWhenNotForeground 0. Applied once.
+		else if (bWorkspaceSession && ParentHWND && !bWorkspaceWindowHidden)
+		{
+			::SetWindowRgn((HWND)ParentHWND, ::CreateRectRgn(0, 0, 0, 0), true);
+			bWorkspaceWindowHidden = true;
 		}
 #endif
 		int32 Cols = FMath::Max(VC.TileColumns, 1);
@@ -313,6 +348,21 @@ bool FDisplayXRCompositor::Initialize(void* InParentHWND, void* InD3DDevice, voi
 		bUseCopyPath = ForceMode.Equals(TEXT("ipc"), ESearchCase::IgnoreCase) || bWorkspaceSession;
 		UE_LOG(LogDisplayXRCompositor, Log, TEXT("Compositor: swapchain path = %s"),
 			bUseCopyPath ? TEXT("IPC array copy (arraySize=2 slice/eye)") : TEXT("in-process single-tiled zero-copy"));
+	}
+
+	// Under the shell UE's top-level window is never the foreground window (the
+	// shell's workspace window is), so by default UE throttles its render loop to
+	// a few fps when it loses focus — which starves the compositor thread of real
+	// frames. Keep it rendering at full rate: UE's equivalent of Unity's "Run in
+	// Background". Paired with the off-screen window park in CompositorLoop so the
+	// still-rendering window shows nothing on the desktop.
+	if (bWorkspaceSession)
+	{
+		if (IConsoleVariable* CVarIdle =
+		        IConsoleManager::Get().FindConsoleVariable(TEXT("t.IdleWhenNotForeground")))
+		{
+			CVarIdle->Set(0, ECVF_SetByCode);
+		}
 	}
 
 	// Child-window strategy:
@@ -574,6 +624,16 @@ int32 FDisplayXRCompositor::AcquireImage_GameThread()
 			UE_LOG(LogDisplayXRCompositor, Warning, TEXT("AcquireColorTexture #%d: BeginFrameReady timeout"), LocalCallCount);
 			GLog->Flush();
 		}
+		return -1;
+	}
+
+	// Session parked / stopping (e.g. the shell closed the app, driving STOPPING).
+	// The compositor thread wakes us via BeginFrameReadyEvent on park, but there is
+	// no live session to acquire from — return no-image so UE completes the frame
+	// and proceeds to shut down, rather than acquiring/waiting on a dead swapchain
+	// (which would crawl at the 500ms timeout and look hung).
+	if (bStopRequested.Load() || (Session && !Session->IsSessionRunning()))
+	{
 		return -1;
 	}
 

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -48,6 +48,36 @@ public:
 	FDisplayXRCompositor* Owner;
 };
 
+void FDisplayXRCompositor::ComputeTileDims(int32& OutTW, int32& OutTH) const
+{
+	FDisplayXRViewConfig VC = Session->GetViewConfig();
+	OutTW = FMath::Max(1, VC.GetTileW());
+	OutTH = FMath::Max(1, VC.GetTileH());
+#if PLATFORM_WINDOWS
+	// Measure the BOUND window (overlay) — under the shell the runtime sizes it to
+	// the workspace window, so this tracks a resize. The device's CacheWindowSize
+	// reads the same HWND, so UE's render rect, the copy source rect, and the
+	// submitted imageRect all agree and the content aspect tracks the window.
+	HWND BoundHWND = (HWND)GetBoundHWND();
+	if (BoundHWND)
+	{
+		RECT pcr = {};
+		if (::GetClientRect(BoundHWND, &pcr))
+		{
+			const int32 BoundW = pcr.right - pcr.left;
+			const int32 BoundH = pcr.bottom - pcr.top;
+			if (BoundW > 0 && BoundH > 0)
+			{
+				const int32 ClampedW = FMath::Min<int32>(BoundW, (int32)SwapchainWidth);
+				const int32 ClampedH = FMath::Min<int32>(BoundH, (int32)SwapchainHeight);
+				OutTW = FMath::Max(1, FMath::RoundToInt(ClampedW * VC.ScaleX));
+				OutTH = FMath::Max(1, FMath::RoundToInt(ClampedH * VC.ScaleY));
+			}
+		}
+	}
+#endif
+}
+
 void FDisplayXRCompositor::CompositorLoop()
 {
 #if PLATFORM_WINDOWS
@@ -136,19 +166,23 @@ void FDisplayXRCompositor::CompositorLoop()
 		// the current window size, and so that both sides agree on tile dims.
 		FDisplayXRViewConfig VC = Session->GetViewConfig();
 		int32 NV = VC.GetViewCount();
-		int32 TW = VC.GetTileW();
-		int32 TH = VC.GetTileH();
+		// Window-relative tile dims (both paths) — the SAME helper the copy uses,
+		// so UE's render rect, the copy source, and this imageRect all agree and
+		// the content aspect tracks the window (correct under resize).
+		int32 TW, TH;
+		ComputeTileDims(TW, TH);
 #if PLATFORM_WINDOWS
-		if (ParentHWND && ChildHWND)
+		// In-process / forced-IPC: keep ChildHWND sized to UE's main window so the
+		// runtime's GetClientRect(ChildHWND) sees it. Under the SHELL we do NOT do
+		// this — the runtime sizes the overlay to the workspace window (it owns the
+		// size), and we measure that (GetBoundHWND) so content tracks the resize.
+		if (!bWorkspaceSession && ParentHWND && ChildHWND)
 		{
 			RECT pcr = {};
 			if (::GetClientRect((HWND)ParentHWND, &pcr))
 			{
 				const int32 ParentW = pcr.right - pcr.left;
 				const int32 ParentH = pcr.bottom - pcr.top;
-
-				// Keep ChildHWND sized to match the parent so runtime's
-				// GetClientRect(ChildHWND) sees the current size.
 				RECT ccr = {};
 				::GetClientRect((HWND)ChildHWND, &ccr);
 				if (ParentW > 0 && ParentH > 0 &&
@@ -156,21 +190,6 @@ void FDisplayXRCompositor::CompositorLoop()
 				{
 					::SetWindowPos((HWND)ChildHWND, nullptr, 0, 0, ParentW, ParentH,
 						SWP_NOZORDER | SWP_NOACTIVATE);
-				}
-
-				// Single-tiled (in-process) path: window-scale the tile sub-rect.
-				// IPC array path keeps FIXED slice dims (TW/TH = GetTileW/H) so
-				// content always fills the fixed slice — a window-scaled tile would
-				// underfill it (black band / shift); AdjustViewRect matches this.
-				if (!bUseCopyPath && ParentW > 0 && ParentH > 0)
-				{
-					// Clamp against the physical swapchain (worst-case panel size).
-					// Spec: swapchain is never reallocated — if the user drags
-					// larger than the panel, cap tile dims at panel scale × view_scale.
-					const int32 ClampedW = FMath::Min<int32>(ParentW, (int32)SwapchainWidth);
-					const int32 ClampedH = FMath::Min<int32>(ParentH, (int32)SwapchainHeight);
-					TW = FMath::Max(1, FMath::RoundToInt(ClampedW * VC.ScaleX));
-					TH = FMath::Max(1, FMath::RoundToInt(ClampedH * VC.ScaleY));
 				}
 			}
 		}
@@ -266,7 +285,8 @@ bool FDisplayXRCompositor::Initialize(void* InParentHWND, void* InD3DDevice, voi
 	{
 		const FString ForceMode = FPlatformMisc::GetEnvironmentVariable(TEXT("XRT_FORCE_MODE"));
 		const FString Workspace = FPlatformMisc::GetEnvironmentVariable(TEXT("DISPLAYXR_WORKSPACE_SESSION"));
-		bUseCopyPath = ForceMode.Equals(TEXT("ipc"), ESearchCase::IgnoreCase) || !Workspace.IsEmpty();
+		bWorkspaceSession = !Workspace.IsEmpty();
+		bUseCopyPath = ForceMode.Equals(TEXT("ipc"), ESearchCase::IgnoreCase) || bWorkspaceSession;
 		UE_LOG(LogDisplayXRCompositor, Log, TEXT("Compositor: swapchain path = %s"),
 			bUseCopyPath ? TEXT("IPC array copy (arraySize=2 slice/eye)") : TEXT("in-process single-tiled zero-copy"));
 	}
@@ -601,8 +621,11 @@ void FDisplayXRCompositor::ReleaseImage_RenderThread(FRHICommandListImmediate& R
 			FRHITexture* Dst = ArraySwapchainRHI[Idx].GetReference();
 			FDisplayXRViewConfig VC = Session->GetViewConfig();
 			const int32 NV = VC.GetViewCount();
-			const int32 TW = VC.GetTileW();
-			const int32 TH = VC.GetTileH();
+			// Window-relative — MUST match UE's AdjustViewRect render rect and the
+			// projection imageRect (same helper, same window), else the copy reads
+			// a different region than UE drew (black band / shifted tile).
+			int32 TW, TH;
+			ComputeTileDims(TW, TH);
 			const int32 Cols = FMath::Max(VC.TileColumns, 1);
 
 			RHICmdList.Transition(FRHITransitionInfo(SwapchainTexture, ERHIAccess::Unknown, ERHIAccess::CopySrc));

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -307,6 +307,16 @@ void FDisplayXRCompositor::CompositorLoop()
 		{
 			::SetWindowRgn((HWND)ParentHWND, ::CreateRectRgn(0, 0, 0, 0), true);
 			bWorkspaceWindowHidden = true;
+			// UE grabbed OS foreground when it showed its game window on launch,
+			// which makes the shell stop displaying the app until the user alt-tabs
+			// back. Now that the window is hidden, hand foreground back to the shell
+			// (captured at module load) so the app shows immediately. UE needs no
+			// foreground here: input arrives via the runtime forward + AddYawInput,
+			// and rendering is kept alive by t.IdleWhenNotForeground 0.
+			if (HWND ShellFg = (HWND)FDisplayXRPlatform::SavedShellForegroundHWND)
+			{
+				if (::IsWindow(ShellFg)) ::SetForegroundWindow(ShellFg);
+			}
 		}
 #endif
 		int32 Cols = FMath::Max(VC.TileColumns, 1);

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -158,7 +158,11 @@ void FDisplayXRCompositor::CompositorLoop()
 						SWP_NOZORDER | SWP_NOACTIVATE);
 				}
 
-				if (ParentW > 0 && ParentH > 0)
+				// Single-tiled (in-process) path: window-scale the tile sub-rect.
+				// IPC array path keeps FIXED slice dims (TW/TH = GetTileW/H) so
+				// content always fills the fixed slice — a window-scaled tile would
+				// underfill it (black band / shift); AdjustViewRect matches this.
+				if (!bUseCopyPath && ParentW > 0 && ParentH > 0)
 				{
 					// Clamp against the physical swapchain (worst-case panel size).
 					// Spec: swapchain is never reallocated — if the user drags

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -4,6 +4,10 @@
 #include "DisplayXRCompositor.h"
 #include "DisplayXRPlatform.h"
 #include "HAL/IConsoleManager.h"
+#include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
@@ -26,6 +30,35 @@ struct XrSwapchainImageD3D12KHR { XrStructureType type; void* next; void* textur
 #if PLATFORM_WINDOWS
 static const wchar_t* OVERLAY_CLASS = L"DisplayXROverlay";
 static bool bClassReg = false;
+
+// Camera-look drag state for OverlayProc (game thread only). The runtime forwards
+// WM_MOUSEMOVE with wParam=0 (no MK_* bits — it synthesizes moves from the shell's
+// IPC cursor stream), so we latch the held state from the button events instead.
+static bool sOverlayBtnHeld = false;
+static bool sOverlayTracking = false;
+static int sOverlayLastX = 0;
+static int sOverlayLastY = 0;
+
+// Drive camera-look straight on the local PlayerController. Under the shell UE's
+// window is never OS-foreground and the cursor lives over the shell window, so
+// Slate routes mouse input (raw OR cursor-based) AWAY from UE's viewport — the
+// look axis never sees it no matter how we inject at the input layer. Skip that
+// layer entirely: AddYaw/PitchInput accumulates onto the controller's rotation
+// input the same way the game's own look mapping does (Pawn::AddControllerYawInput
+// forwards here), so it works regardless of focus/capture/cursor position. Game
+// thread only (OverlayProc runs in UE's message pump). Scale = degrees per pixel.
+static void DisplayXRFeedLook(int dx, int dy)
+{
+	if (!GEngine || !GEngine->GameViewport) return;
+	UWorld* W = GEngine->GameViewport->GetWorld();
+	if (!W) return;
+	APlayerController* PC = W->GetFirstPlayerController();
+	if (!PC) return;
+	const float kScale = 0.15f;
+	if (dx != 0) PC->AddYawInput(dx * kScale);
+	if (dy != 0) PC->AddPitchInput(dy * kScale);
+}
+
 static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
 	// The runtime forwards focused-app input (keyboard/mouse) via PostMessage to
 	// the HWND bound through XR_EXT_win32_window_binding — which for us is this
@@ -41,10 +74,33 @@ static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
 		if (tgt) PostMessageW(tgt, m, w, l & ~(LPARAM)(0xFu << 25));
 		return 0;
 	}
-	case WM_MOUSEMOVE:
-	case WM_LBUTTONDOWN: case WM_LBUTTONUP: case WM_LBUTTONDBLCLK:
-	case WM_RBUTTONDOWN: case WM_RBUTTONUP: case WM_RBUTTONDBLCLK:
-	case WM_MBUTTONDOWN: case WM_MBUTTONUP: case WM_MBUTTONDBLCLK:
+	case WM_MOUSEMOVE: {
+		// While a drag is held (the shell's "left-drag = app input" gesture), feed
+		// the frame-to-frame delta to the camera. wParam has NO button bits here, so
+		// held comes from the latched button events below; seed on the first move.
+		const int mx = (int)(int16_t)(l & 0xFFFF);          // GET_X_LPARAM, no <windowsx.h>
+		const int my = (int)(int16_t)((l >> 16) & 0xFFFF);  // GET_Y_LPARAM (signed)
+		if (sOverlayBtnHeld) {
+			if (sOverlayTracking) DisplayXRFeedLook(mx - sOverlayLastX, my - sOverlayLastY);
+			sOverlayLastX = mx; sOverlayLastY = my; sOverlayTracking = true;
+		}
+		HWND tgt = GetParent(h);
+		if (tgt) PostMessageW(tgt, m, w, l);
+		return 0;
+	}
+	case WM_LBUTTONDOWN: case WM_RBUTTONDOWN: case WM_MBUTTONDOWN:
+	case WM_LBUTTONDBLCLK: case WM_RBUTTONDBLCLK: case WM_MBUTTONDBLCLK: {
+		sOverlayBtnHeld = true; sOverlayTracking = false;  // next move seeds the origin
+		HWND tgt = GetParent(h);
+		if (tgt) PostMessageW(tgt, m, w, l);
+		return 0;
+	}
+	case WM_LBUTTONUP: case WM_RBUTTONUP: case WM_MBUTTONUP: {
+		sOverlayBtnHeld = false; sOverlayTracking = false;
+		HWND tgt = GetParent(h);
+		if (tgt) PostMessageW(tgt, m, w, l);
+		return 0;
+	}
 	case WM_MOUSEWHEEL: case WM_MOUSEHWHEEL: {
 		HWND tgt = GetParent(h);
 		if (tgt) PostMessageW(tgt, m, w, l);

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -180,10 +180,20 @@ void FDisplayXRCompositor::CompositorLoop()
 		PV.SetNum(NV);
 		for (int32 i = 0; i < NV; i++) {
 			PV[i] = {}; PV[i].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
-			FVector E = (i == 0) ? LE : RE;
-			PV[i].pose.position = {(float)E.X, (float)E.Y, (float)E.Z};
-			PV[i].pose.orientation = {0,0,0,1};
-			PV[i].fov = {-0.5f, 0.5f, 0.3f, -0.3f};
+			// Submit the runtime's located pose + off-axis (Kooima) fov from
+			// xrLocateViews (matches cube_handle_d3d12_win). A hardcoded fov is
+			// off-center / wrong-aspect. Fall back only if locate data is missing.
+			FVector P; FQuat Q; XrFovf F;
+			if (Session->GetViewData(i, P, Q, F)) {
+				PV[i].pose.position = {(float)P.X, (float)P.Y, (float)P.Z};
+				PV[i].pose.orientation = {(float)Q.X, (float)Q.Y, (float)Q.Z, (float)Q.W};
+				PV[i].fov = F;
+			} else {
+				FVector E = (i == 0) ? LE : RE;
+				PV[i].pose.position = {(float)E.X, (float)E.Y, (float)E.Z};
+				PV[i].pose.orientation = {0,0,0,1};
+				PV[i].fov = {-0.5f, 0.5f, 0.3f, -0.3f};
+			}
 			PV[i].subImage.swapchain = Swapchain;
 			if (bUseCopyPath) {
 				// IPC array: each eye is its own slice; content copied to slice origin.

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -748,11 +748,23 @@ bool FDisplayXRCompositor::CreateSwapchain()
 		for (auto F : Fmts) { if (F == 87) { SwapchainFormat = F; break; } if (F == 28) SwapchainFormat = F; }
 	}
 
+	// IPC: each array slice is PER-VIEW sized so content fills it (matches Unity).
+	// The private RT UE renders into stays display-sized (SwapchainWidth/Height).
+	uint32 CreateW = SwapchainWidth, CreateH = SwapchainHeight;
+	if (bUseCopyPath) {
+		FDisplayXRViewConfig VC = Session->GetViewConfig();
+		SliceW = VC.GetTileW() > 0 ? (uint32)VC.GetTileW() : (SwapchainWidth / 2);
+		SliceH = VC.GetTileH() > 0 ? (uint32)VC.GetTileH() : (SwapchainHeight / 2);
+		CreateW = SliceW; CreateH = SliceH;
+		UE_LOG(LogDisplayXRCompositor, Log, TEXT("Compositor: IPC array slice dims %ux%u (private RT %ux%u)"),
+			SliceW, SliceH, SwapchainWidth, SwapchainHeight);
+	}
+
 	const uint32 ArrSize = bUseCopyPath ? 2u : 1u;
 	XrSwapchainCreateInfo CI = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
 	CI.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
 	CI.format = SwapchainFormat;
-	CI.sampleCount = 1; CI.width = SwapchainWidth; CI.height = SwapchainHeight;
+	CI.sampleCount = 1; CI.width = CreateW; CI.height = CreateH;
 	CI.faceCount = 1; CI.arraySize = ArrSize; CI.mipCount = 1;
 
 	XrResult r = xrCreateSwapchainFunc(S, &CI, &Swapchain);

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -197,6 +197,30 @@ void FDisplayXRCompositor::CompositorLoop()
 			continue;
 		}
 
+#if PLATFORM_WINDOWS
+		// Hide UE's own top-level window from the desktop (it otherwise shows its
+		// fullscreen mono mirror over the shell). Do it HERE — early, before the
+		// shouldRender gate below — so it's hidden during UE's load/shader phase too
+		// (shouldRender is false then; the old projection-section placement left the
+		// black window visible for several seconds). Clip to an EMPTY region: the
+		// window stays full-size at its origin (the WS_CHILD overlay geometry +
+		// runtime Kooima are untouched and the swapchain present is not redirected)
+		// but shows nothing. Then hand OS foreground back to the shell (captured at
+		// module load) — UE grabbed it when it showed its window, which otherwise
+		// keeps the shell from displaying the app until the user alt-tabs back. UE
+		// needs no foreground: input is the runtime forward + AddYawInput and render
+		// stays alive via t.IdleWhenNotForeground 0. Applied once.
+		if (bWorkspaceSession && ParentHWND && !bWorkspaceWindowHidden)
+		{
+			::SetWindowRgn((HWND)ParentHWND, ::CreateRectRgn(0, 0, 0, 0), true);
+			bWorkspaceWindowHidden = true;
+			if (HWND ShellFg = (HWND)FDisplayXRPlatform::SavedShellForegroundHWND)
+			{
+				if (::IsWindow(ShellFg)) ::SetForegroundWindow(ShellFg);
+			}
+		}
+#endif
+
 		FrameCount++;
 
 		// xrWaitFrame
@@ -289,35 +313,8 @@ void FDisplayXRCompositor::CompositorLoop()
 				}
 			}
 		}
-		// Under the shell, UE's own top-level window would otherwise show its
-		// fullscreen mono mirror on the desktop, over the shell. Hide it WITHOUT
-		// changing its style, size, or position — every other approach perturbs the
-		// 3D content:
-		//   - off-screen park / shrink drags or clips the WS_CHILD overlay the
-		//     runtime measures -> DISTORTED content;
-		//   - WS_EX_LAYERED (transparent) breaks UE's flip-model present to the
-		//     window, UE falls back to a differently-aligned render -> WRONG POV
-		//     (camera too low). (Confirmed: hidden-via-layered <-> POV shifted.)
-		// Instead clip the window to an EMPTY region: the window rect stays
-		// full-size at its origin (overlay geometry + runtime Kooima untouched, the
-		// swapchain present is NOT redirected) but nothing composites to the
-		// desktop. UE keeps rendering its scene (which the plugin copies into the
-		// array swapchain) — paired with t.IdleWhenNotForeground 0. Applied once.
-		else if (bWorkspaceSession && ParentHWND && !bWorkspaceWindowHidden)
-		{
-			::SetWindowRgn((HWND)ParentHWND, ::CreateRectRgn(0, 0, 0, 0), true);
-			bWorkspaceWindowHidden = true;
-			// UE grabbed OS foreground when it showed its game window on launch,
-			// which makes the shell stop displaying the app until the user alt-tabs
-			// back. Now that the window is hidden, hand foreground back to the shell
-			// (captured at module load) so the app shows immediately. UE needs no
-			// foreground here: input arrives via the runtime forward + AddYawInput,
-			// and rendering is kept alive by t.IdleWhenNotForeground 0.
-			if (HWND ShellFg = (HWND)FDisplayXRPlatform::SavedShellForegroundHWND)
-			{
-				if (::IsWindow(ShellFg)) ::SetForegroundWindow(ShellFg);
-			}
-		}
+		// (UE's stray top-level window is hidden + foreground handed back to the
+		// shell earlier in the loop, before the shouldRender gate — see above.)
 #endif
 		int32 Cols = FMath::Max(VC.TileColumns, 1);
 

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -618,8 +618,11 @@ void FDisplayXRCompositor::ReleaseImage_RenderThread(FRHICommandListImmediate& R
 				RHICmdList.CopyTexture(SwapchainTexture, Dst, CopyInfo);
 			}
 			RHICmdList.Transition(FRHITransitionInfo(Dst, ERHIAccess::CopyDest, ERHIAccess::Present));
+			// Flush so the copy is queued before xrReleaseSwapchainImage; rely on
+			// the runtime's swapchain-release GPU sync rather than a full CPU stall
+			// (BlockUntilGPUIdle halved the framerate). If the service ever reads a
+			// torn/incomplete slice, reinstate a *targeted* fence wait here.
 			RHICmdList.SubmitCommandsHint();
-			RHICmdList.BlockUntilGPUIdle();
 		}
 	}
 	else if (SwapchainTexture)

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -26,6 +26,30 @@ struct XrSwapchainImageD3D12KHR { XrStructureType type; void* next; void* textur
 static const wchar_t* OVERLAY_CLASS = L"DisplayXROverlay";
 static bool bClassReg = false;
 static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
+	// The runtime forwards focused-app input (keyboard/mouse) via PostMessage to
+	// the HWND bound through XR_EXT_win32_window_binding — which for us is this
+	// inert child overlay. Relay that input to UE's REAL window (our parent) so
+	// WASD/mouse actually drive the app; otherwise every forwarded key/click hits
+	// DefWindowProcW and is dropped (native apps that bind their real window work).
+	switch (m) {
+	case WM_KEYDOWN: case WM_KEYUP: case WM_SYSKEYDOWN: case WM_SYSKEYUP:
+	case WM_CHAR: case WM_SYSCHAR: {
+		HWND tgt = GetParent(h);
+		// Strip the runtime's modifier-marker bits (25-28, reserved in WM_KEY*
+		// lParam) so UE sees a clean message.
+		if (tgt) PostMessageW(tgt, m, w, l & ~(LPARAM)(0xFu << 25));
+		return 0;
+	}
+	case WM_MOUSEMOVE:
+	case WM_LBUTTONDOWN: case WM_LBUTTONUP: case WM_LBUTTONDBLCLK:
+	case WM_RBUTTONDOWN: case WM_RBUTTONUP: case WM_RBUTTONDBLCLK:
+	case WM_MBUTTONDOWN: case WM_MBUTTONUP: case WM_MBUTTONDBLCLK:
+	case WM_MOUSEWHEEL: case WM_MOUSEHWHEEL: {
+		HWND tgt = GetParent(h);
+		if (tgt) PostMessageW(tgt, m, w, l);
+		return 0;
+	}
+	}
 	return m == WM_NCHITTEST ? HTTRANSPARENT : DefWindowProcW(h, m, w, l);
 }
 static bool RegClass() {

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -66,11 +66,22 @@ static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
 	// WASD/mouse actually drive the app; otherwise every forwarded key/click hits
 	// DefWindowProcW and is dropped (native apps that bind their real window work).
 	switch (m) {
-	case WM_KEYDOWN: case WM_KEYUP: case WM_SYSKEYDOWN: case WM_SYSKEYUP:
-	case WM_CHAR: case WM_SYSCHAR: {
+	case WM_KEYDOWN: case WM_KEYUP: case WM_SYSKEYDOWN: case WM_SYSKEYUP: {
+		// The shell reserves Ctrl for its own chords (Ctrl+L launcher, Ctrl+1/2/3
+		// layouts, Ctrl+Space). The runtime still forwards the lone Ctrl keystroke,
+		// and UE's default pawn binds LeftControl to the MoveUp axis
+		// (ADefaultPawn::InitializeDefaultPawnInputBindings) — so pressing Ctrl
+		// (e.g. for Ctrl+L) jerks the camera vertically. Swallow Ctrl so it never
+		// drives the app under the shell. (Other modifiers still pass through.)
+		if (w == VK_CONTROL || w == VK_LCONTROL || w == VK_RCONTROL) return 0;
 		HWND tgt = GetParent(h);
 		// Strip the runtime's modifier-marker bits (25-28, reserved in WM_KEY*
 		// lParam) so UE sees a clean message.
+		if (tgt) PostMessageW(tgt, m, w, l & ~(LPARAM)(0xFu << 25));
+		return 0;
+	}
+	case WM_CHAR: case WM_SYSCHAR: {
+		HWND tgt = GetParent(h);
 		if (tgt) PostMessageW(tgt, m, w, l & ~(LPARAM)(0xFu << 25));
 		return 0;
 	}

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -185,8 +185,15 @@ void FDisplayXRCompositor::CompositorLoop()
 			PV[i].pose.orientation = {0,0,0,1};
 			PV[i].fov = {-0.5f, 0.5f, 0.3f, -0.3f};
 			PV[i].subImage.swapchain = Swapchain;
-			PV[i].subImage.imageRect.offset = {(i % Cols) * TW, (i / Cols) * TH};
-			PV[i].subImage.imageRect.extent = {TW, TH};
+			if (bUseCopyPath) {
+				// IPC array: each eye is its own slice; content copied to slice origin.
+				PV[i].subImage.imageArrayIndex = (uint32_t)i;
+				PV[i].subImage.imageRect.offset = {0, 0};
+				PV[i].subImage.imageRect.extent = {TW, TH};
+			} else {
+				PV[i].subImage.imageRect.offset = {(i % Cols) * TW, (i / Cols) * TH};
+				PV[i].subImage.imageRect.extent = {TW, TH};
+			}
 		}
 
 		XrCompositionLayerProjection PL = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
@@ -240,6 +247,16 @@ bool FDisplayXRCompositor::Initialize(void* InParentHWND, void* InD3DDevice, voi
 	// would corrupt UE's RHI command-list tracking.
 	if (!CreateRuntimeQueue()) return false;
 
+	// IPC vs in-process: over IPC the single-tiled shared texture is non-coherent
+	// cross-process from UE's process, so we take the arraySize=2 copy path.
+	{
+		const FString ForceMode = FPlatformMisc::GetEnvironmentVariable(TEXT("XRT_FORCE_MODE"));
+		const FString Workspace = FPlatformMisc::GetEnvironmentVariable(TEXT("DISPLAYXR_WORKSPACE_SESSION"));
+		bUseCopyPath = ForceMode.Equals(TEXT("ipc"), ESearchCase::IgnoreCase) || !Workspace.IsEmpty();
+		UE_LOG(LogDisplayXRCompositor, Log, TEXT("Compositor: swapchain path = %s"),
+			bUseCopyPath ? TEXT("IPC array copy (arraySize=2 slice/eye)") : TEXT("in-process single-tiled zero-copy"));
+	}
+
 	// Child-window strategy:
 	//  - Game mode (OverrideCompositorHWND null): keep the historical child
 	//    window. The fullscreen game window has no visible pixels behind it
@@ -276,6 +293,7 @@ void FDisplayXRCompositor::Shutdown()
 {
 	StopCompositorThread();
 	SwapchainImagesRHI.Empty();
+	ArraySwapchainRHI.Empty();
 	DestroySwapchain();
 	DestroyChildWindow();
 #if PLATFORM_WINDOWS
@@ -374,13 +392,51 @@ bool FDisplayXRCompositor::WrapSwapchainImagesAsRHI()
 #if PLATFORM_WINDOWS
 	if (SwapchainImages.Num() == 0) return false;
 
-	SwapchainImagesRHI.Empty(SwapchainImages.Num());
-
 	ID3D12DynamicRHI* DynamicRHI = GetID3D12DynamicRHI();
 	if (!DynamicRHI) {
 		UE_LOG(LogDisplayXRCompositor, Error, TEXT("Compositor: GetID3D12DynamicRHI returned null"));
 		return false;
 	}
+
+	// IPC array path: UE renders both eyes SBS into a PRIVATE RT (display-sized,
+	// so the existing AdjustViewRect tiling is unchanged); we later CopyTexture
+	// each eye into an arraySize=2 slice of the imported image. Wrap the imported
+	// array images separately as the copy DEST.
+	if (bUseCopyPath)
+	{
+		SwapchainImagesRHI.Empty(SwapchainImages.Num());
+		ArraySwapchainRHI.Empty(SwapchainImages.Num());
+		const uint32 W = SwapchainWidth, H = SwapchainHeight;
+		TArray<FTextureRHIRef>& OutPrivate = SwapchainImagesRHI;
+		TArray<FTextureRHIRef>& OutArray   = ArraySwapchainRHI;
+		TArray<FSwapchainImage> InImages = SwapchainImages;
+		ENQUEUE_RENDER_COMMAND(WrapDisplayXRArraySwapchain)(
+			[&OutPrivate, &OutArray, InImages, DynamicRHI, W, H](FRHICommandListImmediate& RHICmdList)
+			{
+				for (const FSwapchainImage& Img : InImages)
+				{
+					const FRHITextureCreateDesc Desc =
+						FRHITextureCreateDesc::Create2D(TEXT("DisplayXRPrivateRT"), (int32)W, (int32)H, PF_R8G8B8A8)
+							.SetFlags(ETextureCreateFlags::RenderTargetable | ETextureCreateFlags::ShaderResource)
+							.SetClearValue(FClearValueBinding::Black)
+							.SetInitialState(ERHIAccess::SRVMask);
+					OutPrivate.Add(RHICmdList.CreateTexture(Desc));
+
+					ID3D12Resource* Res = static_cast<ID3D12Resource*>(Img.D3D12Resource);
+					OutArray.Add(DynamicRHI->RHICreateTexture2DArrayFromResource(
+						PF_R8G8B8A8,
+						ETextureCreateFlags::RenderTargetable | ETextureCreateFlags::ShaderResource,
+						FClearValueBinding::Transparent, Res));
+				}
+			});
+		FlushRenderingCommands();
+		UE_LOG(LogDisplayXRCompositor, Log, TEXT("Compositor: IPC array path — %d private RTs + %d array images"),
+			SwapchainImagesRHI.Num(), ArraySwapchainRHI.Num());
+		GLog->Flush();
+		return SwapchainImagesRHI.Num() > 0 && ArraySwapchainRHI.Num() == SwapchainImagesRHI.Num();
+	}
+
+	SwapchainImagesRHI.Empty(SwapchainImages.Num());
 
 	const ETextureCreateFlags Flags =
 		ETextureCreateFlags::RenderTargetable |
@@ -519,9 +575,42 @@ void FDisplayXRCompositor::ReleaseImage_RenderThread(FRHICommandListImmediate& R
 	}
 	if (Swapchain == XR_NULL_HANDLE || !xrReleaseSwapchainImageFunc) return;
 
-	// Transition swapchain texture to Present before releasing to the runtime.
-	if (SwapchainTexture)
+	if (bUseCopyPath)
 	{
+		// IPC: UE rendered both eyes SBS into the private RT (SwapchainTexture).
+		// Copy each eye's tile into its arraySize=2 slice of the imported image,
+		// then drain so the writes are GPU-complete (cross-process coherence)
+		// before xrReleaseSwapchainImage.
+		const uint32 Idx = AcquiredImageIndex.Load();
+		if (SwapchainTexture && Idx < (uint32)ArraySwapchainRHI.Num() && ArraySwapchainRHI[Idx].IsValid())
+		{
+			FRHITexture* Dst = ArraySwapchainRHI[Idx].GetReference();
+			FDisplayXRViewConfig VC = Session->GetViewConfig();
+			const int32 NV = VC.GetViewCount();
+			const int32 TW = VC.GetTileW();
+			const int32 TH = VC.GetTileH();
+			const int32 Cols = FMath::Max(VC.TileColumns, 1);
+
+			RHICmdList.Transition(FRHITransitionInfo(SwapchainTexture, ERHIAccess::Unknown, ERHIAccess::CopySrc));
+			RHICmdList.Transition(FRHITransitionInfo(Dst, ERHIAccess::Unknown, ERHIAccess::CopyDest));
+			for (int32 i = 0; i < NV; i++)
+			{
+				FRHICopyTextureInfo CopyInfo;
+				CopyInfo.Size = FIntVector(TW, TH, 1);
+				CopyInfo.SourcePosition = FIntVector((i % Cols) * TW, (i / Cols) * TH, 0);
+				CopyInfo.DestPosition = FIntVector(0, 0, 0);
+				CopyInfo.DestSliceIndex = (uint32)i;
+				CopyInfo.NumSlices = 1;
+				RHICmdList.CopyTexture(SwapchainTexture, Dst, CopyInfo);
+			}
+			RHICmdList.Transition(FRHITransitionInfo(Dst, ERHIAccess::CopyDest, ERHIAccess::Present));
+			RHICmdList.SubmitCommandsHint();
+			RHICmdList.BlockUntilGPUIdle();
+		}
+	}
+	else if (SwapchainTexture)
+	{
+		// In-process: UE rendered directly into the swapchain image (zero-copy).
 		RHICmdList.Transition(FRHITransitionInfo(SwapchainTexture, ERHIAccess::Unknown, ERHIAccess::Present));
 		RHICmdList.SubmitCommandsHint();
 	}
@@ -649,14 +738,22 @@ bool FDisplayXRCompositor::CreateSwapchain()
 	TArray<int64_t> Fmts; Fmts.SetNum(FC);
 	xrEnumerateSwapchainFormatsFunc(S, FC, &FC, Fmts.GetData());
 
-	SwapchainFormat = Fmts[0];
-	for (auto F : Fmts) { if (F == 87) { SwapchainFormat = F; break; } if (F == 28) SwapchainFormat = F; }
+	// In-process single-tiled prefers BGRA(87); the IPC array path uses RGBA(28)
+	// (proven coherent cross-process) so the private-RT→slice copy is straight.
+	if (bUseCopyPath) {
+		SwapchainFormat = 28;
+		for (auto F : Fmts) { if (F == 28) { SwapchainFormat = 28; break; } }
+	} else {
+		SwapchainFormat = Fmts[0];
+		for (auto F : Fmts) { if (F == 87) { SwapchainFormat = F; break; } if (F == 28) SwapchainFormat = F; }
+	}
 
+	const uint32 ArrSize = bUseCopyPath ? 2u : 1u;
 	XrSwapchainCreateInfo CI = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
 	CI.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_SAMPLED_BIT;
 	CI.format = SwapchainFormat;
 	CI.sampleCount = 1; CI.width = SwapchainWidth; CI.height = SwapchainHeight;
-	CI.faceCount = 1; CI.arraySize = 1; CI.mipCount = 1;
+	CI.faceCount = 1; CI.arraySize = ArrSize; CI.mipCount = 1;
 
 	XrResult r = xrCreateSwapchainFunc(S, &CI, &Swapchain);
 	if (!XR_SUCCEEDED(r)) { UE_LOG(LogDisplayXRCompositor, Error, TEXT("xrCreateSwapchain failed %d"), (int)r); return false; }

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -67,13 +67,15 @@ static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
 	// DefWindowProcW and is dropped (native apps that bind their real window work).
 	switch (m) {
 	case WM_KEYDOWN: case WM_KEYUP: case WM_SYSKEYDOWN: case WM_SYSKEYUP: {
-		// The shell reserves Ctrl for its own chords (Ctrl+L launcher, Ctrl+1/2/3
-		// layouts, Ctrl+Space). The runtime still forwards the lone Ctrl keystroke,
-		// and UE's default pawn binds LeftControl to the MoveUp axis
-		// (ADefaultPawn::InitializeDefaultPawnInputBindings) — so pressing Ctrl
-		// (e.g. for Ctrl+L) jerks the camera vertically. Swallow Ctrl so it never
-		// drives the app under the shell. (Other modifiers still pass through.)
-		if (w == VK_CONTROL || w == VK_LCONTROL || w == VK_RCONTROL) return 0;
+		// Ctrl flows through to UE like every other key. The shell reserves its own
+		// Ctrl chords (Ctrl+L/1/2/3, Ctrl+Shift+O/C, Ctrl+Space) and the runtime now
+		// buffers the bare Ctrl prefix until the chord disambiguates (#667), so a
+		// shell chord's Ctrl never reaches us — while genuine Ctrl combos the app
+		// wants (Ctrl+Z, a held Ctrl) still arrive. This replaces the old blanket
+		// Ctrl swallow, which blocked ALL Ctrl input under the shell. REQUIRES a
+		// runtime build with the #667 arbitration (runtime ≥ the release noted in
+		// CHANGELOG); against an older runtime, shell-chord Ctrl will again drive
+		// UE's ADefaultPawn MoveUp.
 		HWND tgt = GetParent(h);
 		// Strip the runtime's modifier-marker bits (25-28, reserved in WM_KEY*
 		// lParam) so UE sees a clean message.

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.h
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.h
@@ -110,6 +110,12 @@ private:
 	// that. In-process keeps the v0.4.3 single-tiled zero-copy path unchanged.
 	bool bUseCopyPath = false;                 // XRT_FORCE_MODE=ipc / DISPLAYXR_WORKSPACE_SESSION
 	TArray<FTextureRHIRef> ArraySwapchainRHI;  // wrapped imported arraySize=2 images (copy DEST)
+	// Per-view (per-slice) dims for the IPC array swapchain. MUST equal the tile
+	// dims (content fills the slice, like Unity) — an oversized slice trips the
+	// service's needs_scale → workspace scale-blit path which flips V (UE-only
+	// upside-down under the shell). The private RT stays display-sized for SBS.
+	uint32 SliceW = 0;
+	uint32 SliceH = 0;
 
 	// Compositor thread
 	FRunnableThread* Thread = nullptr;

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.h
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.h
@@ -101,6 +101,16 @@ private:
 	uint32 SwapchainHeight = 0;
 	int64 SwapchainFormat = 0;
 
+	// --- IPC array path ---
+	// The single-tiled arraySize=1 shared texture is non-coherent cross-process
+	// from UE's process (proven: even a dedicated device's writes don't reach the
+	// D3D11 service). The canonical stereo arraySize=2 swapchain IS coherent
+	// (proven on UE's own device). So over IPC we render UE's two eyes SBS into a
+	// private RT, then CopyTexture each eye into an arraySize=2 slice and submit
+	// that. In-process keeps the v0.4.3 single-tiled zero-copy path unchanged.
+	bool bUseCopyPath = false;                 // XRT_FORCE_MODE=ipc / DISPLAYXR_WORKSPACE_SESSION
+	TArray<FTextureRHIRef> ArraySwapchainRHI;  // wrapped imported arraySize=2 images (copy DEST)
+
 	// Compositor thread
 	FRunnableThread* Thread = nullptr;
 	TAtomic<bool> bThreadRunning{false};

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.h
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.h
@@ -104,6 +104,9 @@ private:
 	// Child window
 	void* ChildHWND = nullptr;
 	void* ParentHWND = nullptr;
+	// Shell: set once after clipping ParentHWND to an empty region to hide UE's
+	// top-level mono window from the desktop without moving/resizing/restyling it.
+	bool bWorkspaceWindowHidden = false;
 
 	// UE's D3D12 device (borrowed, not owned) + dedicated runtime queue (owned)
 	void* UEDevice = nullptr;

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.h
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.h
@@ -65,6 +65,12 @@ public:
 	uint32 GetSwapchainWidth() const { return SwapchainWidth; }
 	uint32 GetSwapchainHeight() const { return SwapchainHeight; }
 
+	/** True on the IPC array path: each eye renders at the FIXED per-view slice
+	 *  size (content fills the slice). AdjustViewRect must NOT window-scale tiles
+	 *  there, else a smaller-than-display window underfills the fixed slice
+	 *  (black band / shifted tile). Window-relative perspective is via Kooima. */
+	bool UsesArrayCopyPath() const { return bUseCopyPath; }
+
 private:
 	bool CreateChildWindow(void* InParentHWND);
 	void DestroyChildWindow();

--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.h
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.h
@@ -65,6 +65,13 @@ public:
 	uint32 GetSwapchainWidth() const { return SwapchainWidth; }
 	uint32 GetSwapchainHeight() const { return SwapchainHeight; }
 
+	/** The HWND bound to the OpenXR session (the child overlay, or the parent in
+	 *  the editor-override case). Under the shell the RUNTIME sizes this to the
+	 *  workspace window, so UE + the plugin must measure THIS window (not UE's
+	 *  own top-level window) for render/tile dims, else content can't track a
+	 *  workspace resize. */
+	void* GetBoundHWND() const { return ChildHWND ? ChildHWND : ParentHWND; }
+
 	/** True on the IPC array path: each eye renders at the FIXED per-view slice
 	 *  size (content fills the slice). AdjustViewRect must NOT window-scale tiles
 	 *  there, else a smaller-than-display window underfills the fixed slice
@@ -74,6 +81,11 @@ public:
 private:
 	bool CreateChildWindow(void* InParentHWND);
 	void DestroyChildWindow();
+	// Window-relative per-view tile dims from ParentHWND's client rect (matches the
+	// device's AdjustViewRect math). The IPC array copy AND projection both call
+	// this so UE's rendered tile, the copy source rect, and the submitted imageRect
+	// all agree → content aspect tracks the window (correct under resize).
+	void ComputeTileDims(int32& OutTW, int32& OutTH) const;
 	bool CreateSwapchain();
 	void DestroySwapchain();
 	bool WrapSwapchainImagesAsRHI();
@@ -115,6 +127,7 @@ private:
 	// private RT, then CopyTexture each eye into an arraySize=2 slice and submit
 	// that. In-process keeps the v0.4.3 single-tiled zero-copy path unchanged.
 	bool bUseCopyPath = false;                 // XRT_FORCE_MODE=ipc / DISPLAYXR_WORKSPACE_SESSION
+	bool bWorkspaceSession = false;            // DISPLAYXR_WORKSPACE_SESSION (shell) — runtime owns the overlay size
 	TArray<FTextureRHIRef> ArraySwapchainRHI;  // wrapped imported arraySize=2 images (copy DEST)
 	// Per-view (per-slice) dims for the IPC array swapchain. MUST equal the tile
 	// dims (content fills the slice, like Unity) — an oversized slice trips the

--- a/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
@@ -116,6 +116,22 @@ void FDisplayXRCoreModule::StartupModule()
 	UE_LOG(LogDisplayXRCore, Log, TEXT("DisplayXR: Set DPI awareness to per-monitor"));
 #endif
 
+	// Under the shell (DISPLAYXR_WORKSPACE_SESSION) UE's window is never the OS
+	// foreground window, so UE idles its render + STARTUP when unfocused — the app
+	// comes up stuck on the loading spinner until you alt-tab in. Disable the
+	// not-foreground idle here at module load (PostConfigInit — before the engine
+	// can idle), not in the compositor's late xrCreateSession path. Code-set via
+	// IConsoleManager because t.IdleWhenNotForeground is an ECVF_Cheat cvar the
+	// engine refuses to read from DefaultEngine.ini.
+	if (!FPlatformMisc::GetEnvironmentVariable(TEXT("DISPLAYXR_WORKSPACE_SESSION")).IsEmpty())
+	{
+		if (IConsoleVariable* CVarIdle = IConsoleManager::Get().FindConsoleVariable(TEXT("t.IdleWhenNotForeground")))
+		{
+			CVarIdle->Set(0, ECVF_SetByCode);
+			UE_LOG(LogDisplayXRCore, Log, TEXT("DisplayXR: t.IdleWhenNotForeground=0 (shell: render while unfocused)"));
+		}
+	}
+
 	// Set HMD priority higher than OpenXR/SteamVR so UE picks us
 	float HighestXrPluginPriority = 0.0f;
 	TArray<FString> XrPlugins = { TEXT("OpenXRHMD"), TEXT("SteamVR") };

--- a/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
@@ -130,6 +130,13 @@ void FDisplayXRCoreModule::StartupModule()
 			CVarIdle->Set(0, ECVF_SetByCode);
 			UE_LOG(LogDisplayXRCore, Log, TEXT("DisplayXR: t.IdleWhenNotForeground=0 (shell: render while unfocused)"));
 		}
+#if PLATFORM_WINDOWS
+		// Capture the shell's foreground window NOW (module load, before UE creates
+		// and shows its game window and steals foreground). The compositor hands it
+		// back after hiding UE's window so the shell keeps displaying the app
+		// without the user having to alt-tab back.
+		FDisplayXRPlatform::SavedShellForegroundHWND = (void*)::GetForegroundWindow();
+#endif
 	}
 
 	// Set HMD priority higher than OpenXR/SteamVR so UE picks us
@@ -254,5 +261,6 @@ FDisplayXRSession* FDisplayXRCoreModule::GetSession()
 
 bool FDisplayXRPlatform::bSuppressCompositor = false;
 void* FDisplayXRPlatform::OverrideCompositorHWND = nullptr;
+void* FDisplayXRPlatform::SavedShellForegroundHWND = nullptr;
 
 IMPLEMENT_MODULE(FDisplayXRCoreModule, DisplayXRCore)

--- a/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCoreModule.cpp
@@ -9,6 +9,9 @@
 #include "SceneViewExtension.h"
 #include "Modules/ModuleManager.h"
 #include "HAL/IConsoleManager.h"
+#include "HAL/Runnable.h"
+#include "HAL/RunnableThread.h"
+#include "HAL/ThreadSafeBool.h"
 #include "Framework/Application/IInputProcessor.h"
 #include "Framework/Application/SlateApplication.h"
 #include "GameFramework/PlayerController.h"
@@ -24,6 +27,73 @@
 #endif
 
 DEFINE_LOG_CATEGORY_STATIC(LogDisplayXRCore, Log, All);
+
+#if PLATFORM_WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <windows.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+
+// Hide UE's own top-level desktop windows under the shell, from a thread that is
+// INDEPENDENT of the game thread. During UE's BLOCKING startup load (shaders /
+// level) the game thread is stalled, so the compositor loop — which normally hides
+// the window — hasn't started yet, and UE's black window covers the shell + other
+// apps for several seconds. This watcher clips every top-level visible window owned
+// by our process to an empty region the moment it appears (and hands OS foreground
+// back to the shell once), regardless of the game thread's state. Cross-thread
+// SetWindowRgn is allowed and does not require the owning thread to pump messages.
+// Clipping only hides the desktop composite — UE keeps rendering to the swapchain.
+class FDisplayXRWindowHider : public FRunnable
+{
+public:
+	explicit FDisplayXRWindowHider(void* InShellHWND) : ShellHWND(InShellHWND) {}
+	virtual bool Init() override { return true; }
+	virtual uint32 Run() override
+	{
+		bool bHandedBack = false;
+		int Iter = 0;
+		while (!bStop)
+		{
+			const int Hid = HideProcessTopLevelWindows();
+			if (Hid > 0 && !bHandedBack && ShellHWND && ::IsWindow((HWND)ShellHWND))
+			{
+				::SetForegroundWindow((HWND)ShellHWND);
+				bHandedBack = true;
+			}
+			// Poll fast during the startup-load window, then back off to keep
+			// steady-state overhead negligible (still catches a later re-show).
+			::Sleep(Iter < 1000 ? 30 : 500);
+			++Iter;
+		}
+		return 0;
+	}
+	virtual void Stop() override { bStop = true; }
+
+private:
+	static int HideProcessTopLevelWindows()
+	{
+		struct FCtx { DWORD Pid; int Hid; } Ctx{ ::GetCurrentProcessId(), 0 };
+		::EnumWindows([](HWND Hwnd, LPARAM Lp) -> BOOL
+		{
+			FCtx* C = reinterpret_cast<FCtx*>(Lp);
+			DWORD WPid = 0; ::GetWindowThreadProcessId(Hwnd, &WPid);
+			if (WPid != C->Pid) return 1;                      // other processes
+			if (::GetWindow(Hwnd, GW_OWNER) != nullptr) return 1; // owned popups
+			if (!::IsWindowVisible(Hwnd)) return 1;
+			RECT Box; const int T = ::GetWindowRgnBox(Hwnd, &Box);
+			if (T == NULLREGION) return 1;                     // already clipped empty
+			::SetWindowRgn(Hwnd, ::CreateRectRgn(0, 0, 0, 0), true);
+			++C->Hid;
+			return 1;
+		}, reinterpret_cast<LPARAM>(&Ctx));
+		return Ctx.Hid;
+	}
+	FThreadSafeBool bStop{ false };
+	void* ShellHWND = nullptr;
+};
+
+static FDisplayXRWindowHider* GWindowHider = nullptr;
+static FRunnableThread* GWindowHiderThread = nullptr;
+#endif
 
 // =============================================================================
 // Dev-mode input preprocessor: SHIFT+F1 toggles mouse cursor / input mode on
@@ -136,6 +206,12 @@ void FDisplayXRCoreModule::StartupModule()
 		// back after hiding UE's window so the shell keeps displaying the app
 		// without the user having to alt-tab back.
 		FDisplayXRPlatform::SavedShellForegroundHWND = (void*)::GetForegroundWindow();
+		// Start the window-hider watcher NOW (before UE creates + shows its game
+		// window), so UE's black window is clipped the instant it appears even while
+		// the game thread is blocked loading — it otherwise covers the shell and
+		// other apps for seconds.
+		GWindowHider = new FDisplayXRWindowHider(FDisplayXRPlatform::SavedShellForegroundHWND);
+		GWindowHiderThread = FRunnableThread::Create(GWindowHider, TEXT("DisplayXRWindowHider"));
 #endif
 	}
 
@@ -201,6 +277,16 @@ void FDisplayXRCoreModule::RegisterDevInputProcessor()
 
 void FDisplayXRCoreModule::ShutdownModule()
 {
+#if PLATFORM_WINDOWS
+	if (GWindowHiderThread)
+	{
+		GWindowHiderThread->Kill(true);  // Stop() + wait
+		delete GWindowHiderThread;
+		GWindowHiderThread = nullptr;
+	}
+	if (GWindowHider) { delete GWindowHider; GWindowHider = nullptr; }
+#endif
+
 	AtlasCaptureCmd.Reset();
 
 	if (PostEngineInitHandle.IsValid())

--- a/Source/DisplayXRCore/Private/DisplayXRPlatform.h
+++ b/Source/DisplayXRCore/Private/DisplayXRPlatform.h
@@ -65,4 +65,12 @@ struct FDisplayXRPlatform
 	/** Override HWND for compositor: if non-null, the compositor uses this window
 	 *  instead of the game viewport's HWND. Set by the editor preview module. */
 	DISPLAYXRCORE_API static void* OverrideCompositorHWND;
+
+	/** The OS foreground window captured at module load (PostConfigInit) — under
+	 *  the shell this is the shell/launcher that spawned us. UE grabs foreground
+	 *  when it shows its game window on launch, which makes the shell stop
+	 *  displaying the app until the user alt-tabs back; the compositor hands
+	 *  foreground back to this window once it hides UE's window. Win32 HWND as
+	 *  void*; null off-Windows / outside a shell session. */
+	DISPLAYXRCORE_API static void* SavedShellForegroundHWND;
 };

--- a/Source/DisplayXRCore/Private/DisplayXRSession.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.cpp
@@ -793,15 +793,22 @@ void FDisplayXRSession::LocateViews()
 	{
 		const int32 WriteIdx = 1 - EyeDataReadIndex.Load();
 		FEyeData& ED = EyeDataBuffer[WriteIdx];
+		auto Quat = [](const XrQuaternionf& q) { return FQuat(q.x, q.y, q.z, q.w); };
 		if (ViewCount >= 2)
 		{
 			ED.LeftEye = FVector(Views[0].pose.position.x, Views[0].pose.position.y, Views[0].pose.position.z);
 			ED.RightEye = FVector(Views[1].pose.position.x, Views[1].pose.position.y, Views[1].pose.position.z);
+			ED.LeftOrient = Quat(Views[0].pose.orientation);
+			ED.RightOrient = Quat(Views[1].pose.orientation);
+			ED.LeftFov = Views[0].fov;
+			ED.RightFov = Views[1].fov;
 		}
 		else if (ViewCount >= 1)
 		{
 			ED.LeftEye = FVector(Views[0].pose.position.x, Views[0].pose.position.y, Views[0].pose.position.z);
 			ED.RightEye = ED.LeftEye;
+			ED.LeftOrient = ED.RightOrient = Quat(Views[0].pose.orientation);
+			ED.LeftFov = ED.RightFov = Views[0].fov;
 		}
 		ED.bTracked = bTracked;
 		EyeDataReadIndex.Store(WriteIdx);
@@ -858,6 +865,17 @@ void FDisplayXRSession::GetEyePositions(FVector& OutLeft, FVector& OutRight, boo
 	OutLeft = ED.LeftEye;
 	OutRight = ED.RightEye;
 	bOutTracked = ED.bTracked;
+}
+
+bool FDisplayXRSession::GetViewData(int32 ViewIndex, FVector& OutPos, FQuat& OutOrient, XrFovf& OutFov) const
+{
+	if (ViewIndex < 0 || ViewIndex > 1) return false;
+	const int32 ReadIdx = EyeDataReadIndex.Load();
+	const FEyeData& ED = EyeDataBuffer[ReadIdx];
+	OutPos    = (ViewIndex == 0) ? ED.LeftEye    : ED.RightEye;
+	OutOrient = (ViewIndex == 0) ? ED.LeftOrient : ED.RightOrient;
+	OutFov    = (ViewIndex == 0) ? ED.LeftFov    : ED.RightFov;
+	return true;
 }
 
 bool FDisplayXRSession::RequestDisplayMode(bool bMode3D)

--- a/Source/DisplayXRCore/Private/DisplayXRSession.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.cpp
@@ -1266,6 +1266,22 @@ void FDisplayXRSession::PumpEvents()
 				bSessionRunning.Store(false);
 				UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: STOPPING — session ended, frame loop parked"));
 			}
+			else if (SC->state == XR_SESSION_STATE_EXITING)
+			{
+				// The runtime asked the app to terminate (shell close drives
+				// EXIT_REQUEST -> STOPPING -> EXITING; xrEndSession above queues
+				// EXITING because the runtime set sess->exiting). End state
+				// reached: request UE engine shutdown so the PROCESS actually
+				// exits, instead of spinning a parked, session-less frame loop
+				// forever (the teardown "hang"). Guarded to request exit once.
+				bSessionRunning.Store(false);
+				if (!bExitRequested)
+				{
+					bExitRequested = true;
+					UE_LOG(LogDisplayXRSession, Log, TEXT("DisplayXR Session: EXITING - requesting app exit"));
+					FPlatformMisc::RequestExit(false);
+				}
+			}
 		}
 		EventData = {XR_TYPE_EVENT_DATA_BUFFER};
 	}

--- a/Source/DisplayXRCore/Private/DisplayXRSession.h
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.h
@@ -93,6 +93,12 @@ public:
 	/** Get latest eye positions in OpenXR display-local space (meters). */
 	void GetEyePositions(FVector& OutLeft, FVector& OutRight, bool& bOutTracked) const;
 
+	/** Get the runtime-located per-view pose (position + orientation) and the
+	 *  off-axis (Kooima) fov for view i (0=left, 1=right) from xrLocateViews.
+	 *  Submit these in the projection layer (matches cube_handle_d3d12_win).
+	 *  Returns false if ViewIndex is out of range. */
+	bool GetViewData(int32 ViewIndex, FVector& OutPos, FQuat& OutOrient, XrFovf& OutFov) const;
+
 	/** Request 2D or 3D display mode. Updates ViewConfig on success. */
 	bool RequestDisplayMode(bool bMode3D);
 
@@ -204,6 +210,13 @@ private:
 	{
 		FVector LeftEye = FVector::ZeroVector;
 		FVector RightEye = FVector::ZeroVector;
+		// Runtime-located per-view orientation + off-axis (Kooima) fov from
+		// xrLocateViews — submit these in the projection layer instead of a
+		// hardcoded fov, else the image is off-center / wrong aspect.
+		FQuat LeftOrient = FQuat::Identity;
+		FQuat RightOrient = FQuat::Identity;
+		XrFovf LeftFov = {};
+		XrFovf RightFov = {};
 		bool bTracked = false;
 	};
 	FEyeData EyeDataBuffer[2];

--- a/Source/DisplayXRCore/Private/DisplayXRSession.h
+++ b/Source/DisplayXRCore/Private/DisplayXRSession.h
@@ -170,6 +170,9 @@ private:
 	// CompositorLoop park gate, Tick LocateViews gate).
 	TAtomic<XrSessionState> SessionState{XR_SESSION_STATE_UNKNOWN};
 	TAtomic<bool> bSessionRunning{false};
+	// Set once when XR_SESSION_STATE_EXITING is handled, so the app requests
+	// engine exit exactly once (PumpEvents runs every parked-loop iteration).
+	bool bExitRequested = false;
 
 	// Function pointers (resolved via xrGetInstanceProcAddr)
 	PFN_xrGetInstanceProcAddr xrGetInstanceProcAddrFunc = nullptr;

--- a/Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp
+++ b/Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp
@@ -329,8 +329,21 @@ void FDisplayXRDevice::AdjustViewRect(const int32 ViewIndex, int32& X, int32& Y,
 	// logical RT size was the source of the prior eye-content bleed, not the
 	// tile offsets themselves.
 	CacheWindowSize();
-	const int32 TileW = FMath::Max(1, FMath::RoundToInt(CachedWindowW * CachedViewConfig.ScaleX));
-	const int32 TileH = FMath::Max(1, FMath::RoundToInt(CachedWindowH * CachedViewConfig.ScaleY));
+	int32 TileW, TileH;
+	if (Compositor.IsValid() && Compositor->UsesArrayCopyPath())
+	{
+		// IPC array path: each eye fills a FIXED per-view slice. Window-scaling
+		// the tile here would underfill the fixed slice on a smaller window
+		// (black band / shift); the window-relative perspective is applied by
+		// the runtime's Kooima projection instead.
+		TileW = FMath::Max(1, CachedViewConfig.GetTileW());
+		TileH = FMath::Max(1, CachedViewConfig.GetTileH());
+	}
+	else
+	{
+		TileW = FMath::Max(1, FMath::RoundToInt(CachedWindowW * CachedViewConfig.ScaleX));
+		TileH = FMath::Max(1, FMath::RoundToInt(CachedWindowH * CachedViewConfig.ScaleY));
+	}
 
 	const int32 Cols = FMath::Max(CachedViewConfig.TileColumns, 1);
 	const int32 Col = ViewIndex % Cols;

--- a/Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp
+++ b/Source/DisplayXRCore/Private/Rendering/DisplayXRDevice.cpp
@@ -329,21 +329,12 @@ void FDisplayXRDevice::AdjustViewRect(const int32 ViewIndex, int32& X, int32& Y,
 	// logical RT size was the source of the prior eye-content bleed, not the
 	// tile offsets themselves.
 	CacheWindowSize();
-	int32 TileW, TileH;
-	if (Compositor.IsValid() && Compositor->UsesArrayCopyPath())
-	{
-		// IPC array path: each eye fills a FIXED per-view slice. Window-scaling
-		// the tile here would underfill the fixed slice on a smaller window
-		// (black band / shift); the window-relative perspective is applied by
-		// the runtime's Kooima projection instead.
-		TileW = FMath::Max(1, CachedViewConfig.GetTileW());
-		TileH = FMath::Max(1, CachedViewConfig.GetTileH());
-	}
-	else
-	{
-		TileW = FMath::Max(1, FMath::RoundToInt(CachedWindowW * CachedViewConfig.ScaleX));
-		TileH = FMath::Max(1, FMath::RoundToInt(CachedWindowH * CachedViewConfig.ScaleY));
-	}
+	// Window-relative tile dims (both paths). The IPC array copy + projection use
+	// the SAME window-relative dims (compositor's ComputeTileDims, same HWND), so
+	// the content aspect tracks the window → correct under resize (like the cube),
+	// while the array slice stays fixed-size so it never trips needs_scale.
+	const int32 TileW = FMath::Max(1, FMath::RoundToInt(CachedWindowW * CachedViewConfig.ScaleX));
+	const int32 TileH = FMath::Max(1, FMath::RoundToInt(CachedWindowH * CachedViewConfig.ScaleY));
 
 	const int32 Cols = FMath::Max(CachedViewConfig.TileColumns, 1);
 	const int32 Col = ViewIndex % Cols;
@@ -571,10 +562,19 @@ void FDisplayXRDevice::CacheWindowSize() const
 	uint32 H = DI.DisplayPixelHeight > 0 ? (uint32)DI.DisplayPixelHeight : 1080;
 
 #if PLATFORM_WINDOWS
-	if (GameHWND)
+	// Measure the BOUND window (overlay) once the compositor exists — under the
+	// shell the runtime sizes it to the workspace window, so UE renders at the
+	// workspace size and content tracks a resize. Falls back to UE's own window
+	// (GameHWND) before the compositor/overlay exists.
+	HWND MeasureHWND = (HWND)GameHWND;
+	if (Compositor.IsValid() && Compositor->GetBoundHWND())
+	{
+		MeasureHWND = (HWND)Compositor->GetBoundHWND();
+	}
+	if (MeasureHWND)
 	{
 		RECT rc = {};
-		if (::GetClientRect((HWND)GameHWND, &rc))
+		if (::GetClientRect(MeasureHWND, &rc))
 		{
 			const int32 RectW = rc.right  - rc.left;
 			const int32 RectH = rc.bottom - rc.top;
@@ -954,10 +954,17 @@ void FDisplayXRDevice::ComputeViews()
 	Placement.rect_height_px    = DispPxH;
 
 #if PLATFORM_WINDOWS
-	if (GameHWND)
+	// Use the BOUND overlay (runtime-sized to the workspace window under the shell)
+	// for the render Kooima frustum, so UE renders at the WORKSPACE aspect — not
+	// its own fullscreen window. Otherwise the tile tracks the resize but the
+	// render projection stays 16:9 → content stretches. Falls back to UE's window.
+	HWND Hwnd = (HWND)GameHWND;
+	if (Compositor.IsValid() && Compositor->GetBoundHWND())
 	{
-		HWND Hwnd = (HWND)GameHWND;
-
+		Hwnd = (HWND)Compositor->GetBoundHWND();
+	}
+	if (Hwnd)
+	{
 		RECT rc;
 		GetClientRect(Hwnd, &rc);
 		const float WinPxW = (float)(rc.right - rc.left);


### PR DESCRIPTION
Merges the `feat/ue-ipc-array-swapchain` line into `main` (main was behind the released v0.5.0). Rebase-merge to preserve the individual commits.

## Highlights
- UE renders over IPC via an `arraySize=2` stereo array swapchain; per-view slice sizing so the shell composite doesn't flip UE; runtime-located fov+pose submission.
- First-class shell citizen: overlay relays forwarded keyboard/mouse to UE's real window; camera-look driven from forwarded mouse drags; window-hiding lifecycle fixes for clean load/teardown.
- **#667 Ctrl passthrough (new):** removes the blanket Ctrl swallow added in v0.5.0. The runtime now buffers the bare Ctrl prefix until a chord disambiguates (`displayxr-runtime#668`), so shell chords (Ctrl+L/1/2/3) never leak their Ctrl to UE's `MoveUp`, while genuine Ctrl combos (Ctrl+Z, held Ctrl) pass through.

## Dependency
The Ctrl-passthrough commit **requires a runtime build with the #667 arbitration** (merged in `displayxr-runtime#668`). Against an older runtime, shell-chord Ctrl will again drive `MoveUp`. A patch release (v0.5.1) follows once the runtime release ships.

## Verification
Repackaged UE test app under the shell on Leia hardware: Ctrl+L/1/2/3 drive the shell with no camera move; held Ctrl and Ctrl+Z reach the app. Confirmed working by maintainer.