### PR TITLE
fix(shell,#667): remove the blanket Ctrl swallow — let Ctrl reach UE

### DIFF
--- a/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
+++ b/Source/DisplayXRCore/Private/DisplayXRCompositor.cpp
@@ -67,13 +67,15 @@ static LRESULT CALLBACK OverlayProc(HWND h, UINT m, WPARAM w, LPARAM l) {
 	// DefWindowProcW and is dropped (native apps that bind their real window work).
 	switch (m) {
 	case WM_KEYDOWN: case WM_KEYUP: case WM_SYSKEYDOWN: case WM_SYSKEYUP: {
-		// The shell reserves Ctrl for its own chords (Ctrl+L launcher, Ctrl+1/2/3
-		// layouts, Ctrl+Space). The runtime still forwards the lone Ctrl keystroke,
-		// and UE's default pawn binds LeftControl to the MoveUp axis
-		// (ADefaultPawn::InitializeDefaultPawnInputBindings) — so pressing Ctrl
-		// (e.g. for Ctrl+L) jerks the camera vertically. Swallow Ctrl so it never
-		// drives the app under the shell. (Other modifiers still pass through.)
-		if (w == VK_CONTROL || w == VK_LCONTROL || w == VK_RCONTROL) return 0;
+		// Ctrl flows through to UE like every other key. The shell reserves its own
+		// Ctrl chords (Ctrl+L/1/2/3, Ctrl+Shift+O/C, Ctrl+Space) and the runtime now
+		// buffers the bare Ctrl prefix until the chord disambiguates (#667), so a
+		// shell chord's Ctrl never reaches us — while genuine Ctrl combos the app
+		// wants (Ctrl+Z, a held Ctrl) still arrive. This replaces the old blanket
+		// Ctrl swallow, which blocked ALL Ctrl input under the shell. REQUIRES a
+		// runtime build with the #667 arbitration (runtime ≥ the release noted in
+		// CHANGELOG); against an older runtime, shell-chord Ctrl will again drive
+		// UE's ADefaultPawn MoveUp.
 		HWND tgt = GetParent(h);
 		// Strip the runtime's modifier-marker bits (25-28, reserved in WM_KEY*
 		// lParam) so UE sees a clean message.


### PR DESCRIPTION
Single-hunk removal of the blanket Ctrl swallow in `OverlayProc`, on top of current `main` (Apache-2.0).

The v0.5.0 workaround swallowed **all** Ctrl so shell chords wouldn't drive UE's `ADefaultPawn` `LeftControl → MoveUp` — but that blocked every app's Ctrl use under the shell. The runtime now buffers the bare Ctrl prefix until a chord disambiguates (`displayxr-runtime#668`, issue #667), so shell chords (Ctrl+L/1/2/3) never leak their Ctrl to UE, while genuine Ctrl combos (Ctrl+Z, held Ctrl) pass through. Ctrl now takes the same repost path as every other key.

**Requires** a runtime build with the #667 arbitration; a v0.5.1 patch release follows once the runtime release ships.

Verified end-to-end under the shell on Leia hardware with the UE test app (repackaged with this change): Ctrl+L/1/2/3 drive the shell with no camera move; held Ctrl and Ctrl+Z reach the app. Confirmed by maintainer.

Supersedes #26 (that branch re-introduced already-merged v0.5.0 work from the pre-relicense line).